### PR TITLE
feat: 文字列操作ノードの追加

### DIFF
--- a/src/NodeGraph.Model/Node/FloatToStringNode.cs
+++ b/src/NodeGraph.Model/Node/FloatToStringNode.cs
@@ -1,0 +1,26 @@
+namespace NodeGraph.Model;
+
+[Node("Float To String", "Convert")]
+public partial class FloatToStringNode
+{
+    [Input] private float _input;
+
+    [Property(DisplayName = "Format", Tooltip = "数値フォーマット (例: F2, N2, E3)")]
+    private string _format = "F2";
+
+    [Output] private string _result = string.Empty;
+
+    public void SetFormat(string format)
+    {
+        _format = format;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _result = string.IsNullOrEmpty(_format)
+            ? _input.ToString()
+            : _input.ToString(_format);
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IntToStringNode.cs
+++ b/src/NodeGraph.Model/Node/IntToStringNode.cs
@@ -1,0 +1,26 @@
+namespace NodeGraph.Model;
+
+[Node("Int To String", "Convert")]
+public partial class IntToStringNode
+{
+    [Input] private int _input;
+
+    [Property(DisplayName = "Format", Tooltip = "数値フォーマット (例: D5, N0, X)")]
+    private string _format = string.Empty;
+
+    [Output] private string _result = string.Empty;
+
+    public void SetFormat(string format)
+    {
+        _format = format;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _result = string.IsNullOrEmpty(_format)
+            ? _input.ToString()
+            : _input.ToString(_format);
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/RegexExtractNode.cs
+++ b/src/NodeGraph.Model/Node/RegexExtractNode.cs
@@ -1,0 +1,87 @@
+using System.Text.RegularExpressions;
+
+namespace NodeGraph.Model;
+
+[Node("Regex Extract", "String/Regex")]
+public partial class RegexExtractNode
+{
+    [Input] private string _input = string.Empty;
+
+    [Property(DisplayName = "Pattern", Tooltip = "正規表現パターン (キャプチャグループを含む)")]
+    private string _pattern = string.Empty;
+
+    [Property(DisplayName = "Ignore Case", Tooltip = "大文字小文字を無視するか")]
+    private bool _ignoreCase;
+
+    [Output] private bool _isMatch;
+    [Output] private string _group0 = string.Empty;
+    [Output] private string _group1 = string.Empty;
+    [Output] private string _group2 = string.Empty;
+    [Output] private string _group3 = string.Empty;
+
+    private Regex? _cachedRegex;
+    private string? _cachedPattern;
+    private bool _cachedIgnoreCase;
+
+    public void SetPattern(string pattern)
+    {
+        _pattern = pattern;
+    }
+
+    public void SetIgnoreCase(bool ignoreCase)
+    {
+        _ignoreCase = ignoreCase;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+        var pattern = _pattern ?? string.Empty;
+
+        _isMatch = false;
+        _group0 = _group1 = _group2 = _group3 = string.Empty;
+
+        if (!string.IsNullOrEmpty(pattern))
+        {
+            try
+            {
+                var regex = GetOrCreateRegex(pattern, _ignoreCase);
+                var match = regex.Match(input);
+
+                if (match.Success)
+                {
+                    _isMatch = true;
+                    _group0 = match.Groups[0].Value;
+                    if (match.Groups.Count > 1) _group1 = match.Groups[1].Value;
+                    if (match.Groups.Count > 2) _group2 = match.Groups[2].Value;
+                    if (match.Groups.Count > 3) _group3 = match.Groups[3].Value;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Invalid regex pattern - leave outputs as empty
+            }
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+
+    private Regex GetOrCreateRegex(string pattern, bool ignoreCase)
+    {
+        if (_cachedRegex != null &&
+            _cachedPattern == pattern &&
+            _cachedIgnoreCase == ignoreCase)
+        {
+            return _cachedRegex;
+        }
+
+        var options = RegexOptions.Compiled;
+        if (ignoreCase) options |= RegexOptions.IgnoreCase;
+
+        _cachedRegex = new Regex(pattern, options);
+        _cachedPattern = pattern;
+        _cachedIgnoreCase = ignoreCase;
+
+        return _cachedRegex;
+    }
+}

--- a/src/NodeGraph.Model/Node/RegexMatchNode.cs
+++ b/src/NodeGraph.Model/Node/RegexMatchNode.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+
+namespace NodeGraph.Model;
+
+[Node("Regex Match", "String/Regex")]
+public partial class RegexMatchNode
+{
+    [Input] private string _input = string.Empty;
+
+    [Property(DisplayName = "Pattern", Tooltip = "正規表現パターン")]
+    private string _pattern = string.Empty;
+
+    [Property(DisplayName = "Ignore Case", Tooltip = "大文字小文字を無視するか")]
+    private bool _ignoreCase;
+
+    [Output] private bool _isMatch;
+    [Output] private string _matchValue = string.Empty;
+
+    private Regex? _cachedRegex;
+    private string? _cachedPattern;
+    private bool _cachedIgnoreCase;
+
+    public void SetPattern(string pattern)
+    {
+        _pattern = pattern;
+    }
+
+    public void SetIgnoreCase(bool ignoreCase)
+    {
+        _ignoreCase = ignoreCase;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+        var pattern = _pattern ?? string.Empty;
+
+        if (string.IsNullOrEmpty(pattern))
+        {
+            _isMatch = false;
+            _matchValue = string.Empty;
+        }
+        else
+        {
+            try
+            {
+                var regex = GetOrCreateRegex(pattern, _ignoreCase);
+                var match = regex.Match(input);
+                _isMatch = match.Success;
+                _matchValue = match.Success ? match.Value : string.Empty;
+            }
+            catch (ArgumentException)
+            {
+                _isMatch = false;
+                _matchValue = string.Empty;
+            }
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+
+    private Regex GetOrCreateRegex(string pattern, bool ignoreCase)
+    {
+        if (_cachedRegex != null &&
+            _cachedPattern == pattern &&
+            _cachedIgnoreCase == ignoreCase)
+        {
+            return _cachedRegex;
+        }
+
+        var options = RegexOptions.Compiled;
+        if (ignoreCase) options |= RegexOptions.IgnoreCase;
+
+        _cachedRegex = new Regex(pattern, options);
+        _cachedPattern = pattern;
+        _cachedIgnoreCase = ignoreCase;
+
+        return _cachedRegex;
+    }
+}

--- a/src/NodeGraph.Model/Node/ReplaceNode.cs
+++ b/src/NodeGraph.Model/Node/ReplaceNode.cs
@@ -1,0 +1,28 @@
+namespace NodeGraph.Model;
+
+[Node("Replace", "String")]
+public partial class ReplaceNode
+{
+    [Input] private string _input = string.Empty;
+    [Input] private string _oldValue = string.Empty;
+    [Input] private string _newValue = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+        var oldValue = _oldValue ?? string.Empty;
+        var newValue = _newValue ?? string.Empty;
+
+        if (string.IsNullOrEmpty(oldValue))
+        {
+            _result = input;
+        }
+        else
+        {
+            _result = input.Replace(oldValue, newValue);
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringConcatNode.cs
+++ b/src/NodeGraph.Model/Node/StringConcatNode.cs
@@ -1,0 +1,15 @@
+namespace NodeGraph.Model;
+
+[Node("String Concat", "String")]
+public partial class StringConcatNode
+{
+    [Input] private string _a = string.Empty;
+    [Input] private string _b = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _result = (_a ?? string.Empty) + (_b ?? string.Empty);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringContainsNode.cs
+++ b/src/NodeGraph.Model/Node/StringContainsNode.cs
@@ -1,0 +1,38 @@
+namespace NodeGraph.Model;
+
+[Node("String Contains", "String")]
+public partial class StringContainsNode
+{
+    [Input] private string _input = string.Empty;
+    [Input] private string _search = string.Empty;
+
+    [Property(DisplayName = "Ignore Case", Tooltip = "大文字小文字を無視するか")]
+    private bool _ignoreCase;
+
+    [Output] private bool _result;
+
+    public void SetIgnoreCase(bool ignoreCase)
+    {
+        _ignoreCase = ignoreCase;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+        var search = _search ?? string.Empty;
+
+        if (string.IsNullOrEmpty(search))
+        {
+            _result = true;
+        }
+        else
+        {
+            var comparison = _ignoreCase
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            _result = input.Contains(search, comparison);
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringFormatNode.cs
+++ b/src/NodeGraph.Model/Node/StringFormatNode.cs
@@ -1,0 +1,36 @@
+namespace NodeGraph.Model;
+
+[Node("String Format", "String")]
+public partial class StringFormatNode
+{
+    [Property(DisplayName = "Format", Tooltip = "フォーマット文字列")]
+    private string _format = "{0}";
+
+    [Input] private string _arg0 = string.Empty;
+    [Input] private string _arg1 = string.Empty;
+    [Input] private string _arg2 = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    public void SetFormat(string format)
+    {
+        _format = format;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        try
+        {
+            _result = string.Format(
+                _format ?? "{0}",
+                _arg0 ?? string.Empty,
+                _arg1 ?? string.Empty,
+                _arg2 ?? string.Empty);
+        }
+        catch (FormatException)
+        {
+            _result = _format ?? string.Empty;
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringIndexOfNode.cs
+++ b/src/NodeGraph.Model/Node/StringIndexOfNode.cs
@@ -1,0 +1,33 @@
+namespace NodeGraph.Model;
+
+[Node("String IndexOf", "String")]
+public partial class StringIndexOfNode
+{
+    [Input] private string _input = string.Empty;
+    [Input] private string _search = string.Empty;
+
+    [Property(DisplayName = "Ignore Case", Tooltip = "大文字小文字を無視するか")]
+    private bool _ignoreCase;
+
+    [Output] private int _index;
+    [Output] private bool _found;
+
+    public void SetIgnoreCase(bool ignoreCase)
+    {
+        _ignoreCase = ignoreCase;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+        var search = _search ?? string.Empty;
+
+        var comparison = _ignoreCase
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        _index = input.IndexOf(search, comparison);
+        _found = _index >= 0;
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringInterpolateNode.cs
+++ b/src/NodeGraph.Model/Node/StringInterpolateNode.cs
@@ -1,0 +1,29 @@
+namespace NodeGraph.Model;
+
+[Node("String Interpolate", "String")]
+public partial class StringInterpolateNode
+{
+    [Property(DisplayName = "Template", Tooltip = "テンプレート文字列")]
+    private string _template = "{A}";
+
+    [Input] private string _a = string.Empty;
+    [Input] private string _b = string.Empty;
+    [Input] private string _c = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    public void SetTemplate(string template)
+    {
+        _template = template;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var result = _template ?? string.Empty;
+        result = result.Replace("{A}", _a ?? string.Empty);
+        result = result.Replace("{B}", _b ?? string.Empty);
+        result = result.Replace("{C}", _c ?? string.Empty);
+        _result = result;
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringJoinNode.cs
+++ b/src/NodeGraph.Model/Node/StringJoinNode.cs
@@ -1,0 +1,23 @@
+namespace NodeGraph.Model;
+
+[Node("String Join", "String")]
+public partial class StringJoinNode
+{
+    [Property(DisplayName = "Separator", Tooltip = "結合時の区切り文字")]
+    private string _separator = string.Empty;
+
+    [Input] private string _a = string.Empty;
+    [Input] private string _b = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    public void SetSeparator(string separator)
+    {
+        _separator = separator;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _result = string.Join(_separator ?? string.Empty, _a ?? string.Empty, _b ?? string.Empty);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringLengthNode.cs
+++ b/src/NodeGraph.Model/Node/StringLengthNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+[Node("String Length", "String")]
+public partial class StringLengthNode
+{
+    [Input] private string _input = string.Empty;
+    [Output] private int _length;
+    [Output] private bool _isEmpty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+        _length = input.Length;
+        _isEmpty = input.Length == 0;
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringSplitNode.cs
+++ b/src/NodeGraph.Model/Node/StringSplitNode.cs
@@ -1,0 +1,40 @@
+namespace NodeGraph.Model;
+
+[Node("String Split", "String")]
+public partial class StringSplitNode
+{
+    [Property(DisplayName = "Separator", Tooltip = "分割時の区切り文字")]
+    private string _separator = ",";
+
+    [Input] private string _input = string.Empty;
+    [Output] private string _first = string.Empty;
+    [Output] private string _second = string.Empty;
+    [Output] private int _count;
+
+    public void SetSeparator(string separator)
+    {
+        _separator = separator;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+        var sep = _separator ?? string.Empty;
+
+        if (string.IsNullOrEmpty(sep))
+        {
+            _first = input;
+            _second = string.Empty;
+            _count = string.IsNullOrEmpty(input) ? 0 : 1;
+        }
+        else
+        {
+            var parts = input.Split(new[] { sep }, StringSplitOptions.None);
+            _first = parts.Length > 0 ? parts[0] : string.Empty;
+            _second = parts.Length > 1 ? parts[1] : string.Empty;
+            _count = parts.Length;
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringToFloatNode.cs
+++ b/src/NodeGraph.Model/Node/StringToFloatNode.cs
@@ -1,0 +1,36 @@
+namespace NodeGraph.Model;
+
+[Node("String To Float", "Convert")]
+public partial class StringToFloatNode
+{
+    [Input] private string _input = string.Empty;
+
+    [Property(DisplayName = "Default", Tooltip = "パース失敗時のデフォルト値")]
+    private float _defaultValue;
+
+    [Output] private float _result;
+    [Output] private bool _success;
+
+    public void SetDefaultValue(float defaultValue)
+    {
+        _defaultValue = defaultValue;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+
+        if (float.TryParse(input, out var value))
+        {
+            _result = value;
+            _success = true;
+        }
+        else
+        {
+            _result = _defaultValue;
+            _success = false;
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/StringToIntNode.cs
+++ b/src/NodeGraph.Model/Node/StringToIntNode.cs
@@ -1,0 +1,36 @@
+namespace NodeGraph.Model;
+
+[Node("String To Int", "Convert")]
+public partial class StringToIntNode
+{
+    [Input] private string _input = string.Empty;
+
+    [Property(DisplayName = "Default", Tooltip = "パース失敗時のデフォルト値")]
+    private int _defaultValue;
+
+    [Output] private int _result;
+    [Output] private bool _success;
+
+    public void SetDefaultValue(int defaultValue)
+    {
+        _defaultValue = defaultValue;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+
+        if (int.TryParse(input, out var value))
+        {
+            _result = value;
+            _success = true;
+        }
+        else
+        {
+            _result = _defaultValue;
+            _success = false;
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/SubstringNode.cs
+++ b/src/NodeGraph.Model/Node/SubstringNode.cs
@@ -1,0 +1,31 @@
+namespace NodeGraph.Model;
+
+[Node("Substring", "String")]
+public partial class SubstringNode
+{
+    [Input] private string _input = string.Empty;
+    [Input] private int _startIndex;
+    [Input] private int _length = -1;
+    [Output] private string _result = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+
+        if (_startIndex < 0 || _startIndex >= input.Length)
+        {
+            _result = string.Empty;
+        }
+        else if (_length < 0)
+        {
+            _result = input.Substring(_startIndex);
+        }
+        else
+        {
+            var actualLength = Math.Min(_length, input.Length - _startIndex);
+            _result = input.Substring(_startIndex, actualLength);
+        }
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/ToLowerNode.cs
+++ b/src/NodeGraph.Model/Node/ToLowerNode.cs
@@ -1,0 +1,14 @@
+namespace NodeGraph.Model;
+
+[Node("To Lower", "String")]
+public partial class ToLowerNode
+{
+    [Input] private string _input = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _result = (_input ?? string.Empty).ToLowerInvariant();
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/ToUpperNode.cs
+++ b/src/NodeGraph.Model/Node/ToUpperNode.cs
@@ -1,0 +1,14 @@
+namespace NodeGraph.Model;
+
+[Node("To Upper", "String")]
+public partial class ToUpperNode
+{
+    [Input] private string _input = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _result = (_input ?? string.Empty).ToUpperInvariant();
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/TrimNode.cs
+++ b/src/NodeGraph.Model/Node/TrimNode.cs
@@ -1,0 +1,38 @@
+namespace NodeGraph.Model;
+
+public enum TrimMode
+{
+    Both,
+    Start,
+    End
+}
+
+[Node("Trim", "String")]
+public partial class TrimNode
+{
+    [Input] private string _input = string.Empty;
+
+    [Property(DisplayName = "Mode", Tooltip = "Trim対象: Both/Start/End")]
+    private TrimMode _mode = TrimMode.Both;
+
+    [Output] private string _result = string.Empty;
+
+    public void SetMode(TrimMode mode)
+    {
+        _mode = mode;
+    }
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var input = _input ?? string.Empty;
+
+        _result = _mode switch
+        {
+            TrimMode.Start => input.TrimStart(),
+            TrimMode.End => input.TrimEnd(),
+            _ => input.Trim()
+        };
+
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/test/NodeGraph.UnitTest/RegexNodeTests.cs
+++ b/test/NodeGraph.UnitTest/RegexNodeTests.cs
@@ -1,0 +1,167 @@
+using NodeGraph.Model;
+
+namespace NodeGraph.UnitTest;
+
+/// <summary>
+/// 正規表現ノードのテスト
+/// </summary>
+public class RegexNodeTests
+{
+    [Theory]
+    [InlineData("abc123", @"\d+", false, true, "123")]
+    [InlineData("abcdef", @"\d+", false, false, "")]
+    [InlineData("ABC", @"abc", false, false, "")]
+    [InlineData("ABC", @"abc", true, true, "ABC")]
+    public async Task RegexMatchNode_MatchesPattern(string input, string pattern, bool ignoreCase, bool expectedMatch, string expectedValue)
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue(input);
+
+        var regex = graph.CreateNode<RegexMatchNode>();
+        regex.SetPattern(pattern);
+        regex.SetIgnoreCase(ignoreCase);
+        regex.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(regex.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var isMatchResult = ((OutputPort<bool>)regex.OutputPorts[0]).Value;
+        var matchValueResult = ((OutputPort<string>)regex.OutputPorts[1]).Value;
+
+        Assert.Equal(expectedMatch, isMatchResult);
+        Assert.Equal(expectedValue, matchValueResult);
+    }
+
+    [Fact]
+    public async Task RegexMatchNode_HandlesInvalidPattern()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("test");
+
+        var regex = graph.CreateNode<RegexMatchNode>();
+        regex.SetPattern("[invalid"); // Invalid regex
+        regex.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(regex.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var isMatchResult = ((OutputPort<bool>)regex.OutputPorts[0]).Value;
+        // Should not throw, isMatch should be false
+        Assert.False(isMatchResult);
+    }
+
+    [Fact]
+    public async Task RegexMatchNode_HandlesEmptyPattern()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("test");
+
+        var regex = graph.CreateNode<RegexMatchNode>();
+        regex.SetPattern(""); // Empty pattern
+        regex.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(regex.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var isMatchResult = ((OutputPort<bool>)regex.OutputPorts[0]).Value;
+        Assert.False(isMatchResult);
+    }
+
+    [Fact]
+    public async Task RegexExtractNode_ExtractsGroups()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("John:30:Developer");
+
+        var regex = graph.CreateNode<RegexExtractNode>();
+        regex.SetPattern(@"(\w+):(\d+):(\w+)");
+        regex.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(regex.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var isMatchResult = ((OutputPort<bool>)regex.OutputPorts[0]).Value;
+        var group0Result = ((OutputPort<string>)regex.OutputPorts[1]).Value;
+        var group1Result = ((OutputPort<string>)regex.OutputPorts[2]).Value;
+        var group2Result = ((OutputPort<string>)regex.OutputPorts[3]).Value;
+        var group3Result = ((OutputPort<string>)regex.OutputPorts[4]).Value;
+
+        Assert.True(isMatchResult);
+        Assert.Equal("John:30:Developer", group0Result);
+        Assert.Equal("John", group1Result);
+        Assert.Equal("30", group2Result);
+        Assert.Equal("Developer", group3Result);
+    }
+
+    [Fact]
+    public async Task RegexExtractNode_ReturnsEmptyWhenNoMatch()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("no match here");
+
+        var regex = graph.CreateNode<RegexExtractNode>();
+        regex.SetPattern(@"(\d+):(\d+)");
+        regex.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(regex.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var isMatchResult = ((OutputPort<bool>)regex.OutputPorts[0]).Value;
+        var group1Result = ((OutputPort<string>)regex.OutputPorts[2]).Value;
+
+        Assert.False(isMatchResult);
+        Assert.Equal("", group1Result);
+    }
+
+    [Fact]
+    public async Task RegexNode_CachesCompiledRegex()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+
+        var regex = graph.CreateNode<RegexMatchNode>();
+        regex.SetPattern(@"\d+");
+        regex.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(regex.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+
+        // Execute multiple times - should reuse cached regex
+        for (int i = 0; i < 10; i++)
+        {
+            inputNode.SetValue($"test{i}");
+            await executor.ExecuteAsync();
+        }
+
+        // If we got here without exception, caching is working
+        Assert.True(true);
+    }
+}

--- a/test/NodeGraph.UnitTest/StringNodeTests.cs
+++ b/test/NodeGraph.UnitTest/StringNodeTests.cs
@@ -1,0 +1,523 @@
+using NodeGraph.Model;
+
+namespace NodeGraph.UnitTest;
+
+/// <summary>
+/// 整数結果を取得するテスト用ノード
+/// </summary>
+[Node(HasExecIn = false, HasExecOut = false)]
+public partial class TestIntResultNode
+{
+    [Input] private int _value;
+    public int Value => _value;
+
+    protected override Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// 文字列操作ノードのテスト
+/// </summary>
+public class StringNodeTests
+{
+    #region StringConcatNode Tests
+
+    [Fact]
+    public async Task StringConcatNode_ConcatenatesTwoStrings()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var a = graph.CreateNode<StringConstantNode>();
+        a.SetValue("Hello, ");
+        var b = graph.CreateNode<StringConstantNode>();
+        b.SetValue("World!");
+
+        var concat = graph.CreateNode<StringConcatNode>();
+        concat.ConnectInput(0, a, 0);
+        concat.ConnectInput(1, b, 0);
+
+        start.ExecOutPorts[0].Connect(concat.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)concat.OutputPorts[0]).Value;
+        Assert.Equal("Hello, World!", result);
+    }
+
+    [Fact]
+    public async Task StringConcatNode_HandlesEmptyStrings()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var a = graph.CreateNode<StringConstantNode>();
+        a.SetValue("Test");
+
+        var concat = graph.CreateNode<StringConcatNode>();
+        concat.ConnectInput(0, a, 0);
+        // b is not connected, defaults to empty
+
+        start.ExecOutPorts[0].Connect(concat.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)concat.OutputPorts[0]).Value;
+        Assert.Equal("Test", result);
+    }
+
+    #endregion
+
+    #region StringLengthNode Tests
+
+    [Fact]
+    public async Task StringLengthNode_ReturnsCorrectLength()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var input = graph.CreateNode<StringConstantNode>();
+        input.SetValue("Hello");
+
+        var length = graph.CreateNode<StringLengthNode>();
+        length.ConnectInput(0, input, 0);
+
+        start.ExecOutPorts[0].Connect(length.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<int>)length.OutputPorts[0]).Value;
+        Assert.Equal(5, result);
+    }
+
+    [Fact]
+    public async Task StringLengthNode_ReturnsZeroForEmpty()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var input = graph.CreateNode<StringConstantNode>();
+        input.SetValue("");
+
+        var length = graph.CreateNode<StringLengthNode>();
+        length.ConnectInput(0, input, 0);
+
+        start.ExecOutPorts[0].Connect(length.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var lengthResult = ((OutputPort<int>)length.OutputPorts[0]).Value;
+        var isEmptyResult = ((OutputPort<bool>)length.OutputPorts[1]).Value;
+        Assert.Equal(0, lengthResult);
+        Assert.True(isEmptyResult);
+    }
+
+    #endregion
+
+    #region ToUpperNode Tests
+
+    [Fact]
+    public async Task ToUpperNode_ConvertsToUppercase()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var input = graph.CreateNode<StringConstantNode>();
+        input.SetValue("hello world");
+
+        var upper = graph.CreateNode<ToUpperNode>();
+        upper.ConnectInput(0, input, 0);
+
+        start.ExecOutPorts[0].Connect(upper.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)upper.OutputPorts[0]).Value;
+        Assert.Equal("HELLO WORLD", result);
+    }
+
+    #endregion
+
+    #region ToLowerNode Tests
+
+    [Fact]
+    public async Task ToLowerNode_ConvertsToLowercase()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var input = graph.CreateNode<StringConstantNode>();
+        input.SetValue("HELLO WORLD");
+
+        var lower = graph.CreateNode<ToLowerNode>();
+        lower.ConnectInput(0, input, 0);
+
+        start.ExecOutPorts[0].Connect(lower.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)lower.OutputPorts[0]).Value;
+        Assert.Equal("hello world", result);
+    }
+
+    #endregion
+
+    #region TrimNode Tests
+
+    [Theory]
+    [InlineData("  hello  ", TrimMode.Both, "hello")]
+    [InlineData("  hello  ", TrimMode.Start, "hello  ")]
+    [InlineData("  hello  ", TrimMode.End, "  hello")]
+    public async Task TrimNode_RemovesWhitespace(string input, TrimMode mode, string expected)
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue(input);
+
+        var trim = graph.CreateNode<TrimNode>();
+        trim.SetMode(mode);
+        trim.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(trim.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)trim.OutputPorts[0]).Value;
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region StringContainsNode Tests
+
+    [Theory]
+    [InlineData("Hello World", "World", false, true)]
+    [InlineData("Hello World", "world", false, false)]
+    [InlineData("Hello World", "world", true, true)]
+    [InlineData("Hello World", "", false, true)]
+    public async Task StringContainsNode_FindsSubstring(string input, string search, bool ignoreCase, bool expected)
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue(input);
+        var searchNode = graph.CreateNode<StringConstantNode>();
+        searchNode.SetValue(search);
+
+        var contains = graph.CreateNode<StringContainsNode>();
+        contains.SetIgnoreCase(ignoreCase);
+        contains.ConnectInput(0, inputNode, 0);
+        contains.ConnectInput(1, searchNode, 0);
+
+        start.ExecOutPorts[0].Connect(contains.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<bool>)contains.OutputPorts[0]).Value;
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region StringIndexOfNode Tests
+
+    [Fact]
+    public async Task StringIndexOfNode_FindsPosition()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("Hello World");
+        var searchNode = graph.CreateNode<StringConstantNode>();
+        searchNode.SetValue("World");
+
+        var indexOf = graph.CreateNode<StringIndexOfNode>();
+        indexOf.ConnectInput(0, inputNode, 0);
+        indexOf.ConnectInput(1, searchNode, 0);
+
+        start.ExecOutPorts[0].Connect(indexOf.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var indexResult = ((OutputPort<int>)indexOf.OutputPorts[0]).Value;
+        var foundResult = ((OutputPort<bool>)indexOf.OutputPorts[1]).Value;
+        Assert.Equal(6, indexResult);
+        Assert.True(foundResult);
+    }
+
+    [Fact]
+    public async Task StringIndexOfNode_ReturnsMinusOneWhenNotFound()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("Hello World");
+        var searchNode = graph.CreateNode<StringConstantNode>();
+        searchNode.SetValue("xyz");
+
+        var indexOf = graph.CreateNode<StringIndexOfNode>();
+        indexOf.ConnectInput(0, inputNode, 0);
+        indexOf.ConnectInput(1, searchNode, 0);
+
+        start.ExecOutPorts[0].Connect(indexOf.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var indexResult = ((OutputPort<int>)indexOf.OutputPorts[0]).Value;
+        var foundResult = ((OutputPort<bool>)indexOf.OutputPorts[1]).Value;
+        Assert.Equal(-1, indexResult);
+        Assert.False(foundResult);
+    }
+
+    #endregion
+
+    #region SubstringNode Tests
+
+    [Theory]
+    [InlineData("Hello World", 0, 5, "Hello")]
+    [InlineData("Hello World", 6, -1, "World")]
+    [InlineData("Hello World", 6, 100, "World")]
+    [InlineData("Hello World", 100, 5, "")]
+    public async Task SubstringNode_ExtractsCorrectly(string input, int startIndex, int length, string expected)
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue(input);
+        var startIndexNode = graph.CreateNode<IntConstantNode>();
+        startIndexNode.SetValue(startIndex);
+        var lengthNode = graph.CreateNode<IntConstantNode>();
+        lengthNode.SetValue(length);
+
+        var substring = graph.CreateNode<SubstringNode>();
+        substring.ConnectInput(0, inputNode, 0);
+        substring.ConnectInput(1, startIndexNode, 0);
+        substring.ConnectInput(2, lengthNode, 0);
+
+        start.ExecOutPorts[0].Connect(substring.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)substring.OutputPorts[0]).Value;
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region ReplaceNode Tests
+
+    [Fact]
+    public async Task ReplaceNode_ReplacesSubstring()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("Hello World");
+        var oldValueNode = graph.CreateNode<StringConstantNode>();
+        oldValueNode.SetValue("World");
+        var newValueNode = graph.CreateNode<StringConstantNode>();
+        newValueNode.SetValue("Universe");
+
+        var replace = graph.CreateNode<ReplaceNode>();
+        replace.ConnectInput(0, inputNode, 0);
+        replace.ConnectInput(1, oldValueNode, 0);
+        replace.ConnectInput(2, newValueNode, 0);
+
+        start.ExecOutPorts[0].Connect(replace.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)replace.OutputPorts[0]).Value;
+        Assert.Equal("Hello Universe", result);
+    }
+
+    [Fact]
+    public async Task ReplaceNode_ReplacesAllOccurrences()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("a-b-c-d");
+        var oldValueNode = graph.CreateNode<StringConstantNode>();
+        oldValueNode.SetValue("-");
+        var newValueNode = graph.CreateNode<StringConstantNode>();
+        newValueNode.SetValue("_");
+
+        var replace = graph.CreateNode<ReplaceNode>();
+        replace.ConnectInput(0, inputNode, 0);
+        replace.ConnectInput(1, oldValueNode, 0);
+        replace.ConnectInput(2, newValueNode, 0);
+
+        start.ExecOutPorts[0].Connect(replace.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)replace.OutputPorts[0]).Value;
+        Assert.Equal("a_b_c_d", result);
+    }
+
+    #endregion
+
+    #region StringJoinNode Tests
+
+    [Fact]
+    public async Task StringJoinNode_JoinsWithSeparator()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var a = graph.CreateNode<StringConstantNode>();
+        a.SetValue("Hello");
+        var b = graph.CreateNode<StringConstantNode>();
+        b.SetValue("World");
+
+        var join = graph.CreateNode<StringJoinNode>();
+        join.SetSeparator(", ");
+        join.ConnectInput(0, a, 0);
+        join.ConnectInput(1, b, 0);
+
+        start.ExecOutPorts[0].Connect(join.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)join.OutputPorts[0]).Value;
+        Assert.Equal("Hello, World", result);
+    }
+
+    #endregion
+
+    #region StringSplitNode Tests
+
+    [Fact]
+    public async Task StringSplitNode_SplitsBySeparator()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var input = graph.CreateNode<StringConstantNode>();
+        input.SetValue("a,b,c");
+
+        var split = graph.CreateNode<StringSplitNode>();
+        split.SetSeparator(",");
+        split.ConnectInput(0, input, 0);
+
+        start.ExecOutPorts[0].Connect(split.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var firstResult = ((OutputPort<string>)split.OutputPorts[0]).Value;
+        var secondResult = ((OutputPort<string>)split.OutputPorts[1]).Value;
+        var countResult = ((OutputPort<int>)split.OutputPorts[2]).Value;
+
+        Assert.Equal("a", firstResult);
+        Assert.Equal("b", secondResult);
+        Assert.Equal(3, countResult);
+    }
+
+    #endregion
+
+    #region StringFormatNode Tests
+
+    [Fact]
+    public async Task StringFormatNode_FormatsString()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var arg0 = graph.CreateNode<StringConstantNode>();
+        arg0.SetValue("World");
+
+        var format = graph.CreateNode<StringFormatNode>();
+        format.SetFormat("Hello, {0}!");
+        format.ConnectInput(0, arg0, 0);
+
+        start.ExecOutPorts[0].Connect(format.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)format.OutputPorts[0]).Value;
+        Assert.Equal("Hello, World!", result);
+    }
+
+    [Fact]
+    public async Task StringFormatNode_HandlesMultipleArgs()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var arg0 = graph.CreateNode<StringConstantNode>();
+        arg0.SetValue("Alice");
+        var arg1 = graph.CreateNode<StringConstantNode>();
+        arg1.SetValue("30");
+
+        var format = graph.CreateNode<StringFormatNode>();
+        format.SetFormat("Name: {0}, Age: {1}");
+        format.ConnectInput(0, arg0, 0);
+        format.ConnectInput(1, arg1, 0);
+
+        start.ExecOutPorts[0].Connect(format.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)format.OutputPorts[0]).Value;
+        Assert.Equal("Name: Alice, Age: 30", result);
+    }
+
+    #endregion
+
+    #region StringInterpolateNode Tests
+
+    [Fact]
+    public async Task StringInterpolateNode_InterpolatesTemplate()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var a = graph.CreateNode<StringConstantNode>();
+        a.SetValue("Alice");
+        var b = graph.CreateNode<StringConstantNode>();
+        b.SetValue("30");
+
+        var interpolate = graph.CreateNode<StringInterpolateNode>();
+        interpolate.SetTemplate("Name: {A}, Age: {B}");
+        interpolate.ConnectInput(0, a, 0);
+        interpolate.ConnectInput(1, b, 0);
+
+        start.ExecOutPorts[0].Connect(interpolate.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)interpolate.OutputPorts[0]).Value;
+        Assert.Equal("Name: Alice, Age: 30", result);
+    }
+
+    #endregion
+}

--- a/test/NodeGraph.UnitTest/TypeConversionNodeTests.cs
+++ b/test/NodeGraph.UnitTest/TypeConversionNodeTests.cs
@@ -1,0 +1,173 @@
+using NodeGraph.Model;
+
+namespace NodeGraph.UnitTest;
+
+/// <summary>
+/// 型変換ノードのテスト
+/// </summary>
+public class TypeConversionNodeTests
+{
+    #region IntToStringNode Tests
+
+    [Theory]
+    [InlineData(42, "", "42")]
+    [InlineData(42, "D5", "00042")]
+    [InlineData(255, "X", "FF")]
+    [InlineData(1234, "N0", "1,234")]
+    public async Task IntToStringNode_FormatsCorrectly(int input, string format, string expected)
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<IntConstantNode>();
+        inputNode.SetValue(input);
+
+        var convert = graph.CreateNode<IntToStringNode>();
+        convert.SetFormat(format);
+        convert.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(convert.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)convert.OutputPorts[0]).Value;
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region FloatToStringNode Tests
+
+    [Fact]
+    public async Task FloatToStringNode_FormatsWithPrecision()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<FloatConstantNode>();
+        inputNode.SetValue(3.14159f);
+
+        var convert = graph.CreateNode<FloatToStringNode>();
+        convert.SetFormat("F2");
+        convert.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(convert.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)convert.OutputPorts[0]).Value;
+        Assert.Equal("3.14", result);
+    }
+
+    [Fact]
+    public async Task FloatToStringNode_FormatsWithNoDecimal()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<FloatConstantNode>();
+        inputNode.SetValue(3.99f);
+
+        var convert = graph.CreateNode<FloatToStringNode>();
+        convert.SetFormat("F0");
+        convert.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(convert.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<string>)convert.OutputPorts[0]).Value;
+        Assert.Equal("4", result);
+    }
+
+    #endregion
+
+    #region StringToIntNode Tests
+
+    [Theory]
+    [InlineData("42", 0, 42, true)]
+    [InlineData("invalid", 0, 0, false)]
+    [InlineData("invalid", 99, 99, false)]
+    [InlineData("-123", 0, -123, true)]
+    public async Task StringToIntNode_ParsesOrReturnsDefault(string input, int defaultValue, int expected, bool expectedSuccess)
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue(input);
+
+        var convert = graph.CreateNode<StringToIntNode>();
+        convert.SetDefaultValue(defaultValue);
+        convert.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(convert.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<int>)convert.OutputPorts[0]).Value;
+        var successResult = ((OutputPort<bool>)convert.OutputPorts[1]).Value;
+
+        Assert.Equal(expected, result);
+        Assert.Equal(expectedSuccess, successResult);
+    }
+
+    #endregion
+
+    #region StringToFloatNode Tests
+
+    [Fact]
+    public async Task StringToFloatNode_ParsesValidFloat()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("3.14");
+
+        var convert = graph.CreateNode<StringToFloatNode>();
+        convert.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(convert.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<float>)convert.OutputPorts[0]).Value;
+        var successResult = ((OutputPort<bool>)convert.OutputPorts[1]).Value;
+
+        Assert.Equal(3.14f, result, 0.001f);
+        Assert.True(successResult);
+    }
+
+    [Fact]
+    public async Task StringToFloatNode_ReturnsDefaultForInvalid()
+    {
+        var graph = new Graph();
+
+        var start = graph.CreateNode<StartNode>();
+        var inputNode = graph.CreateNode<StringConstantNode>();
+        inputNode.SetValue("not a number");
+
+        var convert = graph.CreateNode<StringToFloatNode>();
+        convert.SetDefaultValue(1.5f);
+        convert.ConnectInput(0, inputNode, 0);
+
+        start.ExecOutPorts[0].Connect(convert.ExecInPorts[0]);
+
+        var executor = graph.CreateExecutor();
+        await executor.ExecuteAsync();
+
+        var result = ((OutputPort<float>)convert.OutputPorts[0]).Value;
+        var successResult = ((OutputPort<bool>)convert.OutputPorts[1]).Value;
+
+        Assert.Equal(1.5f, result, 0.001f);
+        Assert.False(successResult);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Issue #6 で要求された18個の文字列操作ノードを追加
- 結合・分割、フォーマット、検索・抽出、変換、正規表現、型変換の各カテゴリをカバー
- 全ノードは ExecutionNode として実装（実行フロー制御対応）

## 追加されたノード

| カテゴリ | ノード | 説明 |
|---------|--------|------|
| String | StringConcatNode | 2つの文字列を結合 |
| String | StringJoinNode | セパレータで結合 |
| String | StringSplitNode | 区切り文字で分割 |
| String | StringFormatNode | string.Format相当 |
| String | StringInterpolateNode | テンプレート補間 |
| String | StringContainsNode | 部分文字列判定 |
| String | StringIndexOfNode | 位置検索 |
| String | SubstringNode | 部分文字列抽出 |
| String | StringLengthNode | 文字列長取得 |
| String | ToUpperNode | 大文字変換 |
| String | ToLowerNode | 小文字変換 |
| String | TrimNode | 空白除去 |
| String | ReplaceNode | 文字列置換 |
| String/Regex | RegexMatchNode | 正規表現マッチ |
| String/Regex | RegexExtractNode | キャプチャ抽出 |
| Convert | IntToStringNode | int → string |
| Convert | FloatToStringNode | float → string |
| Convert | StringToIntNode | string → int |
| Convert | StringToFloatNode | string → float |

## Test plan
- [x] StringNodeTests: 文字列操作ノードのテスト
- [x] RegexNodeTests: 正規表現ノードのテスト
- [x] TypeConversionNodeTests: 型変換ノードのテスト
- [x] 全201テストがパス

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)