### PR TITLE
feat: Add I/O nodes for file, HTTP, JSON, and path operations

### DIFF
--- a/src/NodeGraph.Model/Node/IO/Directory/CreateDirectoryNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Directory/CreateDirectoryNode.cs
@@ -1,0 +1,16 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// ディレクトリを作成するノード
+/// </summary>
+[Node("Create Directory", "IO/Directory")]
+public partial class CreateDirectoryNode
+{
+    [Input] private string _path = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        System.IO.Directory.CreateDirectory(_path);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Directory/DirectoryExistsNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Directory/DirectoryExistsNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// ディレクトリの存在を確認するノード
+/// </summary>
+[Node("Directory Exists", "IO/Directory", HasExecIn = false, HasExecOut = false)]
+public partial class DirectoryExistsNode
+{
+    [Input] private string _path = string.Empty;
+    [Output] private bool _exists;
+
+    protected override Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _exists = System.IO.Directory.Exists(_path);
+        return Task.CompletedTask;
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/File/FileAppendTextNode.cs
+++ b/src/NodeGraph.Model/Node/IO/File/FileAppendTextNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// テキストファイルに追記するノード
+/// </summary>
+[Node("Append Text File", "IO/File")]
+public partial class FileAppendTextNode
+{
+    [Input] private string _path = string.Empty;
+    [Input] private string _content = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        await File.AppendAllTextAsync(_path, _content, context.CancellationToken);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/File/FileExistsNode.cs
+++ b/src/NodeGraph.Model/Node/IO/File/FileExistsNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// ファイルの存在を確認するノード
+/// </summary>
+[Node("File Exists", "IO/File", HasExecIn = false, HasExecOut = false)]
+public partial class FileExistsNode
+{
+    [Input] private string _path = string.Empty;
+    [Output] private bool _exists;
+
+    protected override Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _exists = File.Exists(_path);
+        return Task.CompletedTask;
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/File/FileReadBytesNode.cs
+++ b/src/NodeGraph.Model/Node/IO/File/FileReadBytesNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// バイナリファイルを読み込むノード
+/// </summary>
+[Node("Read Bytes File", "IO/File")]
+public partial class FileReadBytesNode
+{
+    [Input] private string _path = string.Empty;
+    [Output] private byte[] _data = [];
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _data = await File.ReadAllBytesAsync(_path, context.CancellationToken);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/File/FileReadTextNode.cs
+++ b/src/NodeGraph.Model/Node/IO/File/FileReadTextNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// テキストファイルを読み込むノード
+/// </summary>
+[Node("Read Text File", "IO/File")]
+public partial class FileReadTextNode
+{
+    [Input] private string _path = string.Empty;
+    [Output] private string _content = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _content = await File.ReadAllTextAsync(_path, context.CancellationToken);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/File/FileWriteBytesNode.cs
+++ b/src/NodeGraph.Model/Node/IO/File/FileWriteBytesNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// バイナリファイルに書き込むノード
+/// </summary>
+[Node("Write Bytes File", "IO/File")]
+public partial class FileWriteBytesNode
+{
+    [Input] private string _path = string.Empty;
+    [Input] private byte[] _data = [];
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        await File.WriteAllBytesAsync(_path, _data, context.CancellationToken);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/File/FileWriteTextNode.cs
+++ b/src/NodeGraph.Model/Node/IO/File/FileWriteTextNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// テキストファイルに書き込むノード
+/// </summary>
+[Node("Write Text File", "IO/File")]
+public partial class FileWriteTextNode
+{
+    [Input] private string _path = string.Empty;
+    [Input] private string _content = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        await File.WriteAllTextAsync(_path, _content, context.CancellationToken);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Http/HttpGetNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Http/HttpGetNode.cs
@@ -1,0 +1,28 @@
+using System.Net.Http;
+
+namespace NodeGraph.Model;
+
+/// <summary>
+/// HTTP GETリクエストを送信するノード
+/// </summary>
+[Node("HTTP GET", "IO/Http")]
+public partial class HttpGetNode
+{
+    private static readonly HttpClient HttpClient = new();
+
+    [Input] private string _url = string.Empty;
+    [Output] private string _response = string.Empty;
+    [Output] private int _statusCode;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        using var response = await HttpClient.GetAsync(_url, context.CancellationToken);
+        _statusCode = (int)response.StatusCode;
+#if NETSTANDARD2_1
+        _response = await response.Content.ReadAsStringAsync();
+#else
+        _response = await response.Content.ReadAsStringAsync(context.CancellationToken);
+#endif
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Http/HttpPostNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Http/HttpPostNode.cs
@@ -1,0 +1,33 @@
+using System.Net.Http;
+using System.Text;
+
+namespace NodeGraph.Model;
+
+/// <summary>
+/// HTTP POSTリクエストを送信するノード（JSON body対応）
+/// </summary>
+[Node("HTTP POST", "IO/Http")]
+public partial class HttpPostNode
+{
+    private static readonly HttpClient HttpClient = new();
+
+    [Input] private string _url = string.Empty;
+    [Input] private string _body = string.Empty;
+    [Property(DisplayName = "Content Type", Tooltip = "リクエストボディのContent-Type")]
+    private string _contentType = "application/json";
+    [Output] private string _response = string.Empty;
+    [Output] private int _statusCode;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        using var content = new StringContent(_body, Encoding.UTF8, _contentType);
+        using var response = await HttpClient.PostAsync(_url, content, context.CancellationToken);
+        _statusCode = (int)response.StatusCode;
+#if NETSTANDARD2_1
+        _response = await response.Content.ReadAsStringAsync();
+#else
+        _response = await response.Content.ReadAsStringAsync(context.CancellationToken);
+#endif
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Json/JsonParseNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Json/JsonParseNode.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+
+namespace NodeGraph.Model;
+
+/// <summary>
+/// JSON文字列から指定したパスの値を抽出するノード
+/// </summary>
+[Node("JSON Parse", "IO/Json")]
+public partial class JsonParseNode
+{
+    [Input] private string _json = string.Empty;
+    [Input] private string _path = string.Empty;
+    [Output] private string _value = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        if (string.IsNullOrEmpty(_json))
+        {
+            _value = string.Empty;
+            await context.ExecuteOutAsync(0);
+            return;
+        }
+
+        using var doc = JsonDocument.Parse(_json);
+        _value = GetValueByPath(doc.RootElement, _path);
+        await context.ExecuteOutAsync(0);
+    }
+
+    /// <summary>
+    /// JSONパスから値を取得する
+    /// パス例: "data.items[0].name" or "items[2]" or "name"
+    /// </summary>
+    private static string GetValueByPath(JsonElement element, string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return element.ToString();
+        }
+
+        var current = element;
+        var segments = ParsePath(path);
+
+        foreach (var segment in segments)
+        {
+            if (segment.IsArrayIndex)
+            {
+                if (current.ValueKind != JsonValueKind.Array)
+                    return string.Empty;
+
+                if (segment.Index < 0 || segment.Index >= current.GetArrayLength())
+                    return string.Empty;
+
+                current = current[segment.Index];
+            }
+            else
+            {
+                if (current.ValueKind != JsonValueKind.Object)
+                    return string.Empty;
+
+                if (!current.TryGetProperty(segment.Name, out var next))
+                    return string.Empty;
+
+                current = next;
+            }
+        }
+
+        return current.ValueKind switch
+        {
+            JsonValueKind.String => current.GetString() ?? string.Empty,
+            JsonValueKind.Number => current.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => string.Empty,
+            _ => current.GetRawText()
+        };
+    }
+
+    private static List<PathSegment> ParsePath(string path)
+    {
+        var segments = new List<PathSegment>();
+        var i = 0;
+
+        while (i < path.Length)
+        {
+            // Skip dots
+            if (path[i] == '.')
+            {
+                i++;
+                continue;
+            }
+
+            // Array index
+            if (path[i] == '[')
+            {
+                var endBracket = path.IndexOf(']', i);
+                if (endBracket == -1) break;
+
+                var indexStr = path.Substring(i + 1, endBracket - i - 1);
+                if (int.TryParse(indexStr, out var index))
+                {
+                    segments.Add(new PathSegment { IsArrayIndex = true, Index = index });
+                }
+                i = endBracket + 1;
+                continue;
+            }
+
+            // Property name
+            var start = i;
+            while (i < path.Length && path[i] != '.' && path[i] != '[')
+            {
+                i++;
+            }
+
+            if (i > start)
+            {
+                segments.Add(new PathSegment { IsArrayIndex = false, Name = path.Substring(start, i - start) });
+            }
+        }
+
+        return segments;
+    }
+
+    private struct PathSegment
+    {
+        public bool IsArrayIndex;
+        public int Index;
+        public string Name;
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Path/GetDirectoryNameNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Path/GetDirectoryNameNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// パスからディレクトリ名を取得するノード
+/// </summary>
+[Node("Get Directory Name", "IO/Path")]
+public partial class GetDirectoryNameNode
+{
+    [Input] private string _path = string.Empty;
+    [Output] private string _directoryName = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _directoryName = Path.GetDirectoryName(_path) ?? string.Empty;
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Path/GetExtensionNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Path/GetExtensionNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// パスから拡張子を取得するノード
+/// </summary>
+[Node("Get Extension", "IO/Path")]
+public partial class GetExtensionNode
+{
+    [Input] private string _path = string.Empty;
+    [Output] private string _extension = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _extension = Path.GetExtension(_path);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Path/GetFileNameNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Path/GetFileNameNode.cs
@@ -1,0 +1,17 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// パスからファイル名を取得するノード
+/// </summary>
+[Node("Get File Name", "IO/Path")]
+public partial class GetFileNameNode
+{
+    [Input] private string _path = string.Empty;
+    [Output] private string _fileName = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _fileName = Path.GetFileName(_path);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/src/NodeGraph.Model/Node/IO/Path/PathCombineNode.cs
+++ b/src/NodeGraph.Model/Node/IO/Path/PathCombineNode.cs
@@ -1,0 +1,18 @@
+namespace NodeGraph.Model;
+
+/// <summary>
+/// 2つのパスを結合するノード
+/// </summary>
+[Node("Combine Path", "IO/Path")]
+public partial class PathCombineNode
+{
+    [Input] private string _path1 = string.Empty;
+    [Input] private string _path2 = string.Empty;
+    [Output] private string _result = string.Empty;
+
+    protected override async Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _result = Path.Combine(_path1, _path2);
+        await context.ExecuteOutAsync(0);
+    }
+}

--- a/test/NodeGraph.UnitTest/IO/IONodesTest.cs
+++ b/test/NodeGraph.UnitTest/IO/IONodesTest.cs
@@ -1,0 +1,333 @@
+using NodeGraph.Model;
+
+namespace NodeGraph.UnitTest.IO;
+
+/// <summary>
+/// I/Oノードのテスト
+/// </summary>
+public class IONodesTest : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public IONodesTest()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"NodeGraph_IOTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+
+    #region Path Operations
+
+    [Fact]
+    public async Task PathCombineNode_CombinesTwoPaths()
+    {
+        var graph = new Graph();
+        var path1 = graph.CreateNode<StringConstantNode>();
+        path1.SetValue("C:\\Users");
+        var path2 = graph.CreateNode<StringConstantNode>();
+        path2.SetValue("test.txt");
+
+        var combine = graph.CreateNode<PathCombineNode>();
+        combine.ConnectInput(0, path1, 0);
+        combine.ConnectInput(1, path2, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(combine.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)combine.OutputPorts[0]).Value;
+        Assert.Equal(Path.Combine("C:\\Users", "test.txt"), result);
+    }
+
+    [Fact]
+    public async Task GetFileNameNode_ExtractsFileName()
+    {
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue("C:\\Users\\test\\document.txt");
+
+        var getFileName = graph.CreateNode<GetFileNameNode>();
+        getFileName.ConnectInput(0, path, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(getFileName.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)getFileName.OutputPorts[0]).Value;
+        Assert.Equal("document.txt", result);
+    }
+
+    [Fact]
+    public async Task GetDirectoryNameNode_ExtractsDirectoryName()
+    {
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue("C:\\Users\\test\\document.txt");
+
+        var getDirectoryName = graph.CreateNode<GetDirectoryNameNode>();
+        getDirectoryName.ConnectInput(0, path, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(getDirectoryName.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)getDirectoryName.OutputPorts[0]).Value;
+        Assert.Equal("C:\\Users\\test", result);
+    }
+
+    [Fact]
+    public async Task GetExtensionNode_ExtractsExtension()
+    {
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue("document.txt");
+
+        var getExtension = graph.CreateNode<GetExtensionNode>();
+        getExtension.ConnectInput(0, path, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(getExtension.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)getExtension.OutputPorts[0]).Value;
+        Assert.Equal(".txt", result);
+    }
+
+    #endregion
+
+    #region File Existence
+
+    [Fact]
+    public async Task FileExistsNode_ReturnsTrueForExistingFile()
+    {
+        var testFile = Path.Combine(_testDirectory, "exists.txt");
+        await File.WriteAllTextAsync(testFile, "test content");
+
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue(testFile);
+
+        var fileExists = graph.CreateNode<FileExistsNode>();
+        fileExists.ConnectInput(0, path, 0);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<bool>)fileExists.OutputPorts[0]).Value;
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task FileExistsNode_ReturnsFalseForNonExistingFile()
+    {
+        var testFile = Path.Combine(_testDirectory, "nonexistent.txt");
+
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue(testFile);
+
+        var fileExists = graph.CreateNode<FileExistsNode>();
+        fileExists.ConnectInput(0, path, 0);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<bool>)fileExists.OutputPorts[0]).Value;
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task DirectoryExistsNode_ReturnsTrueForExistingDirectory()
+    {
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue(_testDirectory);
+
+        var dirExists = graph.CreateNode<DirectoryExistsNode>();
+        dirExists.ConnectInput(0, path, 0);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<bool>)dirExists.OutputPorts[0]).Value;
+        Assert.True(result);
+    }
+
+    #endregion
+
+    #region File Read/Write
+
+    [Fact]
+    public async Task FileWriteAndReadText_RoundTrip()
+    {
+        var testFile = Path.Combine(_testDirectory, "roundtrip.txt");
+        const string content = "Hello, NodeGraph!";
+
+        // Write
+        var writeGraph = new Graph();
+        var writePath = writeGraph.CreateNode<StringConstantNode>();
+        writePath.SetValue(testFile);
+        var writeContent = writeGraph.CreateNode<StringConstantNode>();
+        writeContent.SetValue(content);
+
+        var writeNode = writeGraph.CreateNode<FileWriteTextNode>();
+        writeNode.ConnectInput(0, writePath, 0);
+        writeNode.ConnectInput(1, writeContent, 0);
+
+        var writeStart = writeGraph.CreateNode<StartNode>();
+        writeStart.ExecOutPorts[0].Connect(writeNode.ExecInPorts[0]);
+
+        await writeGraph.CreateExecutor().ExecuteAsync();
+
+        // Read
+        var readGraph = new Graph();
+        var readPath = readGraph.CreateNode<StringConstantNode>();
+        readPath.SetValue(testFile);
+
+        var readNode = readGraph.CreateNode<FileReadTextNode>();
+        readNode.ConnectInput(0, readPath, 0);
+
+        var readStart = readGraph.CreateNode<StartNode>();
+        readStart.ExecOutPorts[0].Connect(readNode.ExecInPorts[0]);
+
+        await readGraph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)readNode.OutputPorts[0]).Value;
+        Assert.Equal(content, result);
+    }
+
+    [Fact]
+    public async Task FileAppendTextNode_AppendsContent()
+    {
+        var testFile = Path.Combine(_testDirectory, "append.txt");
+        await File.WriteAllTextAsync(testFile, "Line1\n");
+
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue(testFile);
+        var content = graph.CreateNode<StringConstantNode>();
+        content.SetValue("Line2\n");
+
+        var appendNode = graph.CreateNode<FileAppendTextNode>();
+        appendNode.ConnectInput(0, path, 0);
+        appendNode.ConnectInput(1, content, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(appendNode.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = await File.ReadAllTextAsync(testFile);
+        Assert.Equal("Line1\nLine2\n", result);
+    }
+
+    #endregion
+
+    #region Directory Operations
+
+    [Fact]
+    public async Task CreateDirectoryNode_CreatesDirectory()
+    {
+        var newDir = Path.Combine(_testDirectory, "newdir");
+
+        var graph = new Graph();
+        var path = graph.CreateNode<StringConstantNode>();
+        path.SetValue(newDir);
+
+        var createDir = graph.CreateNode<CreateDirectoryNode>();
+        createDir.ConnectInput(0, path, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(createDir.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        Assert.True(Directory.Exists(newDir));
+    }
+
+    #endregion
+
+    #region JSON Operations
+
+    [Fact]
+    public async Task JsonParseNode_ExtractsSimpleValue()
+    {
+        const string json = """{"name":"John","age":30}""";
+
+        var graph = new Graph();
+        var jsonInput = graph.CreateNode<StringConstantNode>();
+        jsonInput.SetValue(json);
+        var pathInput = graph.CreateNode<StringConstantNode>();
+        pathInput.SetValue("name");
+
+        var parseNode = graph.CreateNode<JsonParseNode>();
+        parseNode.ConnectInput(0, jsonInput, 0);
+        parseNode.ConnectInput(1, pathInput, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(parseNode.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)parseNode.OutputPorts[0]).Value;
+        Assert.Equal("John", result);
+    }
+
+    [Fact]
+    public async Task JsonParseNode_ExtractsNestedValue()
+    {
+        const string json = """{"data":{"items":[{"id":1},{"id":2}]}}""";
+
+        var graph = new Graph();
+        var jsonInput = graph.CreateNode<StringConstantNode>();
+        jsonInput.SetValue(json);
+        var pathInput = graph.CreateNode<StringConstantNode>();
+        pathInput.SetValue("data.items[1].id");
+
+        var parseNode = graph.CreateNode<JsonParseNode>();
+        parseNode.ConnectInput(0, jsonInput, 0);
+        parseNode.ConnectInput(1, pathInput, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(parseNode.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)parseNode.OutputPorts[0]).Value;
+        Assert.Equal("2", result);
+    }
+
+    [Fact]
+    public async Task JsonParseNode_ReturnsEmptyForInvalidPath()
+    {
+        const string json = """{"name":"John"}""";
+
+        var graph = new Graph();
+        var jsonInput = graph.CreateNode<StringConstantNode>();
+        jsonInput.SetValue(json);
+        var pathInput = graph.CreateNode<StringConstantNode>();
+        pathInput.SetValue("nonexistent");
+
+        var parseNode = graph.CreateNode<JsonParseNode>();
+        parseNode.ConnectInput(0, jsonInput, 0);
+        parseNode.ConnectInput(1, pathInput, 0);
+
+        var start = graph.CreateNode<StartNode>();
+        start.ExecOutPorts[0].Connect(parseNode.ExecInPorts[0]);
+
+        await graph.CreateExecutor().ExecuteAsync();
+
+        var result = ((OutputPort<string>)parseNode.OutputPorts[0]).Value;
+        Assert.Equal(string.Empty, result);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- ファイル操作、HTTP通信、JSON操作、パス操作のI/Oノードを追加
- 16個の新規ノードを実装
- 13件のテストを追加

### 実装ノード一覧

**ファイル操作 (IO/File)**
- `FileReadTextNode` - テキストファイル読み込み
- `FileReadBytesNode` - バイナリファイル読み込み
- `FileExistsNode` - ファイル存在確認
- `FileWriteTextNode` - テキスト書き込み
- `FileWriteBytesNode` - バイナリ書き込み
- `FileAppendTextNode` - テキスト追記

**ディレクトリ操作 (IO/Directory)**
- `DirectoryExistsNode` - ディレクトリ存在確認
- `CreateDirectoryNode` - ディレクトリ作成

**HTTP通信 (IO/Http)**
- `HttpGetNode` - HTTP GETリクエスト
- `HttpPostNode` - HTTP POSTリクエスト (JSON body対応)

**JSON操作 (IO/Json)**
- `JsonParseNode` - JSONパース・値抽出

**パス操作 (IO/Path)**
- `PathCombineNode` - パス結合
- `GetFileNameNode` - ファイル名取得
- `GetDirectoryNameNode` - ディレクトリ名取得
- `GetExtensionNode` - 拡張子取得

## Test plan

- [x] パス操作ノードのテスト
- [x] ファイル存在確認ノードのテスト
- [x] ファイル読み書きのラウンドトリップテスト
- [x] ディレクトリ作成のテスト
- [x] JSONパースのテスト（シンプル値、ネスト値、無効パス）

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)