### PR TITLE
feat: Avalonia WebAssembly対応とダッシュボードUI実装 (#3)

### DIFF
--- a/.run/NodeGraph.Web (Browser).run.xml
+++ b/.run/NodeGraph.Web (Browser).run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="NodeGraph.Web (Browser)" type="CompoundRunConfigurationType">
+    <toRun name="NodeGraph.Web - Build" type="DotNetProject" />
+    <toRun name="NodeGraph.Web - Serve" type="ShConfigurationType" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/NodeGraph.Web - Serve.run.xml
+++ b/.run/NodeGraph.Web - Serve.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="NodeGraph.Web - Serve" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="dotnet build src/NodeGraph.Web/NodeGraph.Web.csproj &amp;&amp; dotnet serve -d src/NodeGraph.Web/bin/Debug/net9.0-browser/browser-wasm/AppBundle -p 5000 -o" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="cmd" />
+    <option name="INTERPRETER_OPTIONS" value="/c" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/NodeGraph.Web - Serve.run.xml
+++ b/.run/NodeGraph.Web - Serve.run.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="NodeGraph.Web - Serve" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="dotnet build src/NodeGraph.Web/NodeGraph.Web.csproj &amp;&amp; dotnet serve -d src/NodeGraph.Web/bin/Debug/net9.0-browser/browser-wasm/AppBundle -p 5000 -o" />
+    <option name="SCRIPT_TEXT" value="dotnet build src/NodeGraph.Web/NodeGraph.Web.csproj; if ($LASTEXITCODE -eq 0) { dotnet serve -d src/NodeGraph.Web/bin/Debug/net9.0-browser/browser-wasm/AppBundle -p 5000 -o }" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
-    <option name="INTERPRETER_PATH" value="cmd" />
-    <option name="INTERPRETER_OPTIONS" value="/c" />
+    <option name="INTERPRETER_PATH" value="powershell" />
+    <option name="INTERPRETER_OPTIONS" value="-Command" />
     <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="false" />
     <method v="2" />

--- a/NodeGraph.slnx
+++ b/NodeGraph.slnx
@@ -5,6 +5,7 @@
         <Project Path="src\NodeGraph.Editor\NodeGraph.Editor.csproj" Type="C#" />
         <Project Path="src\NodeGraph.Generator\NodeGraph.Generator.csproj" Type="C#" />
         <Project Path="src\NodeGraph.Sandbox\NodeGraph.Sandbox.csproj" Type="C#" />
+        <Project Path="src\NodeGraph.Web\NodeGraph.Web.csproj" Type="C#" />
     </Folder>
     <Folder Name="/test/">
         <Project Path="test\NodeGraph.UnitTest\NodeGraph.UnitTest.csproj" Type="C#" />

--- a/src/NodeGraph.Editor/Controls/GraphControl.cs
+++ b/src/NodeGraph.Editor/Controls/GraphControl.cs
@@ -13,6 +13,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
+using Avalonia.Controls.ApplicationLifetimes;
 using NodeGraph.Editor.Models;
 using NodeGraph.Editor.Primitives;
 using NodeGraph.Editor.Selection;
@@ -35,6 +36,13 @@ public partial class GraphControl : TemplatedControl
     private Canvas? _overlayCanvas;
     private Border? _touchGuard;
     private Canvas? _uiCanvas;
+
+    // ノード追加パネル（オーバーレイ）用
+    private Canvas? _addNodeOverlay;
+    private TextBox? _addNodeSearchBox;
+    private TreeView? _addNodeTreeView;
+    private Point _addNodeClickPosition;
+    private AddNodeWindowViewModel? _addNodeViewModel;
 
     public GraphControl()
     {
@@ -109,6 +117,19 @@ public partial class GraphControl : TemplatedControl
         _uiCanvas = e.NameScope.Find<Canvas>("PART_UICanvas");
         _gridDecorator = e.NameScope.Find<GridDecorator>("PART_GridDecorator");
         _touchGuard = e.NameScope.Find<Border>("PART_TouchGuard");
+
+        // ノード追加パネル（オーバーレイ）
+        _addNodeOverlay = e.NameScope.Find<Canvas>("PART_AddNodeOverlay");
+        _addNodeSearchBox = e.NameScope.Find<TextBox>("PART_AddNodeSearchBox");
+        _addNodeTreeView = e.NameScope.Find<TreeView>("PART_AddNodeTreeView");
+        var addNodeOverlayBackground = e.NameScope.Find<Border>("PART_AddNodeOverlayBackground");
+        if (addNodeOverlayBackground != null)
+        {
+            addNodeOverlayBackground.PointerPressed += OnAddNodeOverlayBackgroundPressed;
+        }
+
+        // オーバーレイのイベントを設定
+        SetupAddNodeOverlay();
 
         if (_canvas != null)
         {
@@ -375,6 +396,28 @@ public partial class GraphControl : TemplatedControl
     {
         get => GetValue(IsReadOnlyProperty);
         set => SetValue(IsReadOnlyProperty, value);
+    }
+
+    public static readonly StyledProperty<bool> IsAddNodePanelVisibleProperty = AvaloniaProperty.Register<GraphControl, bool>(nameof(IsAddNodePanelVisible));
+
+    /// <summary>
+    /// ノード追加パネル（オーバーレイ）の表示状態
+    /// </summary>
+    public bool IsAddNodePanelVisible
+    {
+        get => GetValue(IsAddNodePanelVisibleProperty);
+        set => SetValue(IsAddNodePanelVisibleProperty, value);
+    }
+
+    public static readonly StyledProperty<Point> AddNodePanelPositionProperty = AvaloniaProperty.Register<GraphControl, Point>(nameof(AddNodePanelPosition));
+
+    /// <summary>
+    /// ノード追加パネルの表示位置
+    /// </summary>
+    public Point AddNodePanelPosition
+    {
+        get => GetValue(AddNodePanelPositionProperty);
+        set => SetValue(AddNodePanelPositionProperty, value);
     }
 
     #endregion
@@ -664,18 +707,191 @@ public partial class GraphControl : TemplatedControl
 
     #region Add Node
 
+    private void SetupAddNodeOverlay()
+    {
+        if (_addNodeSearchBox != null)
+        {
+            _addNodeSearchBox.TextChanged += OnAddNodeSearchTextChanged;
+            _addNodeSearchBox.KeyDown += OnAddNodeSearchKeyDown;
+        }
+
+        if (_addNodeTreeView != null)
+        {
+            _addNodeTreeView.DoubleTapped += OnAddNodeTreeViewDoubleTapped;
+            _addNodeTreeView.KeyDown += OnAddNodeTreeViewKeyDown;
+        }
+    }
+
+    private void OnAddNodeSearchTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_addNodeViewModel != null && _addNodeSearchBox != null)
+        {
+            _addNodeViewModel.SearchText = _addNodeSearchBox.Text ?? string.Empty;
+        }
+    }
+
+    private void OnAddNodeSearchKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            HideAddNodeOverlay();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter)
+        {
+            ConfirmAddNodeSelection();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down && _addNodeTreeView != null)
+        {
+            _addNodeTreeView.Focus();
+            e.Handled = true;
+        }
+    }
+
+    private void OnAddNodeTreeViewKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            HideAddNodeOverlay();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter)
+        {
+            ConfirmAddNodeSelection();
+            e.Handled = true;
+        }
+    }
+
+    private void OnAddNodeTreeViewDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        // ダブルタップされた要素からNodeTreeItemを取得
+        if (e.Source is Control control)
+        {
+            var item = control.DataContext as NodeTreeItem;
+            // 親要素をたどってNodeTreeItemを探す
+            var current = control;
+            while (item == null && current != null)
+            {
+                item = current.DataContext as NodeTreeItem;
+                current = current.Parent as Control;
+            }
+
+            if (item?.NodeTypeInfo != null)
+            {
+                ConfirmAddNodeSelection(item);
+                return;
+            }
+        }
+
+        // フォールバック: TreeViewの選択アイテムを使用
+        if (_addNodeTreeView?.SelectedItem is NodeTreeItem selectedItem)
+        {
+            ConfirmAddNodeSelection(selectedItem);
+        }
+    }
+
+    private void ConfirmAddNodeSelection(NodeTreeItem? item = null)
+    {
+        // 引数が無い場合はTreeViewの選択アイテムを使用
+        item ??= _addNodeTreeView?.SelectedItem as NodeTreeItem;
+
+        if (item?.NodeTypeInfo != null)
+        {
+            var selectedNodeType = item.NodeTypeInfo;
+            HideAddNodeOverlay();
+
+            // キャンバス座標に変換してノードを作成
+            if (_canvas != null)
+            {
+                var canvasPosition = this.TranslatePoint(_addNodeClickPosition, _canvas);
+                if (canvasPosition.HasValue)
+                {
+                    CreateNode(selectedNodeType, canvasPosition.Value);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// オーバーレイの背景がクリックされた時に閉じる
+    /// </summary>
+    private void OnAddNodeOverlayBackgroundPressed(object? sender, PointerPressedEventArgs e)
+    {
+        HideAddNodeOverlay();
+        e.Handled = true;
+    }
+
+    private void ShowAddNodeOverlay(Point position, NodeTypeService nodeTypeService)
+    {
+        _addNodeClickPosition = position;
+        _addNodeViewModel = new AddNodeWindowViewModel(nodeTypeService);
+
+        if (_addNodeTreeView != null)
+        {
+            _addNodeTreeView.ItemsSource = _addNodeViewModel.TreeItems;
+            _addNodeTreeView.Bind(TreeView.SelectedItemProperty,
+                new Avalonia.Data.Binding(nameof(AddNodeWindowViewModel.SelectedItem))
+                {
+                    Source = _addNodeViewModel,
+                    Mode = Avalonia.Data.BindingMode.TwoWay
+                });
+        }
+
+        if (_addNodeSearchBox != null)
+        {
+            _addNodeSearchBox.Text = string.Empty;
+        }
+
+        // パネル位置を設定（画面からはみ出さないように調整）
+        var panelWidth = 220.0;
+        var panelHeight = 300.0;
+        var x = Math.Min(position.X, Bounds.Width - panelWidth - 10);
+        var y = Math.Min(position.Y, Bounds.Height - panelHeight - 10);
+        AddNodePanelPosition = new Point(Math.Max(10, x), Math.Max(10, y));
+
+        IsAddNodePanelVisible = true;
+
+        // 検索ボックスにフォーカス
+        Dispatcher.UIThread.Post(() => _addNodeSearchBox?.Focus(), DispatcherPriority.Input);
+    }
+
+    private void HideAddNodeOverlay()
+    {
+        IsAddNodePanelVisible = false;
+        _addNodeViewModel = null;
+
+        if (_addNodeTreeView != null)
+        {
+            _addNodeTreeView.ItemsSource = null;
+        }
+    }
+
     private async Task ShowAddNodeWindow(Point clickPosition)
     {
         if (Graph == null || _canvas == null)
             return;
 
-        // NodeTypeServiceを取得
+        // NodeTypeServiceを取得（デスクトップはDIコンテナから、それ以外は直接作成）
+        NodeTypeService? nodeTypeService = null;
+
         var app = Application.Current as App;
-        var nodeTypeService = app?.Services?.GetService<NodeTypeService>();
+        if (app?.Services != null)
+        {
+            nodeTypeService = app.Services.GetService<NodeTypeService>();
+        }
 
-        if (nodeTypeService == null)
+        // DIコンテナから取得できない場合は直接作成
+        nodeTypeService ??= new NodeTypeService();
+
+        // ブラウザ環境（SingleViewApplicationLifetime）ではオーバーレイを使用
+        if (Application.Current?.ApplicationLifetime is ISingleViewApplicationLifetime)
+        {
+            ShowAddNodeOverlay(clickPosition, nodeTypeService);
             return;
+        }
 
+        // デスクトップ環境では従来のWindow方式
         // 親ウィンドウを取得
         if (this.GetVisualRoot() is not Window window)
             return;

--- a/src/NodeGraph.Editor/Themes/GraphControl.axaml
+++ b/src/NodeGraph.Editor/Themes/GraphControl.axaml
@@ -90,6 +90,51 @@
                     Background="Transparent"
                     IsVisible="{Binding IsInputBlocked, RelativeSource={RelativeSource TemplatedParent}}"
                     IsHitTestVisible="True" />
+
+            <!-- ノード追加パネル（オーバーレイ） -->
+            <Canvas x:Name="PART_AddNodeOverlay"
+                    IsVisible="{Binding IsAddNodePanelVisible, RelativeSource={RelativeSource TemplatedParent}}"
+                    IsHitTestVisible="True">
+              <!-- 背景クリックで閉じる -->
+              <Border x:Name="PART_AddNodeOverlayBackground"
+                      Background="Transparent"
+                      Width="{Binding $parent[Canvas].Bounds.Width}"
+                      Height="{Binding $parent[Canvas].Bounds.Height}" />
+              <!-- パネル本体 -->
+              <Border x:Name="PART_AddNodePanel"
+                      Canvas.Left="{Binding AddNodePanelPosition.X, RelativeSource={RelativeSource TemplatedParent}}"
+                      Canvas.Top="{Binding AddNodePanelPosition.Y, RelativeSource={RelativeSource TemplatedParent}}"
+                      Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                      BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                      BorderThickness="1"
+                      CornerRadius="4"
+                      Width="220"
+                      Height="300"
+                      BoxShadow="0 4 16 #40000000">
+                <Grid RowDefinitions="Auto,*">
+                  <!-- 検索ボックス -->
+                  <TextBox x:Name="PART_AddNodeSearchBox"
+                           Grid.Row="0"
+                           Watermark="Search nodes..."
+                           BorderThickness="0"
+                           CornerRadius="4,4,0,0"
+                           Margin="8,8,8,4" />
+                  <!-- ノードリスト -->
+                  <Border Grid.Row="1" Margin="4,0,4,4">
+                    <TreeView x:Name="PART_AddNodeTreeView"
+                              Background="Transparent"
+                              CornerRadius="0,0,4,4">
+                      <TreeView.ItemTemplate>
+                        <TreeDataTemplate x:CompileBindings="False" ItemsSource="{Binding Children}">
+                          <TextBlock Text="{Binding Name}"
+                                     FontWeight="{Binding FontWeight}" />
+                        </TreeDataTemplate>
+                      </TreeView.ItemTemplate>
+                    </TreeView>
+                  </Border>
+                </Grid>
+              </Border>
+            </Canvas>
           </Grid>
         </Border>
       </ControlTemplate>

--- a/src/NodeGraph.Web/NodeGraph.Web.csproj
+++ b/src/NodeGraph.Web/NodeGraph.Web.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0-browser</TargetFramework>
+        <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+
+        <!-- AOT Compilation for production -->
+        <RunAOTCompilation Condition="'$(Configuration)' == 'Release'">true</RunAOTCompilation>
+        <PublishTrimmed>true</PublishTrimmed>
+        <TrimMode>full</TrimMode>
+        <InvariantGlobalization>true</InvariantGlobalization>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia" Version="11.3.10" />
+        <PackageReference Include="Avalonia.Browser" Version="11.3.10" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.10" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.10" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\NodeGraph.Editor\NodeGraph.Editor.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/NodeGraph.Web/NodeGraph.Web.csproj
+++ b/src/NodeGraph.Web/NodeGraph.Web.csproj
@@ -29,4 +29,18 @@
         <ProjectReference Include="..\NodeGraph.Editor\NodeGraph.Editor.csproj" />
     </ItemGroup>
 
+    <!-- Copy wwwroot contents to AppBundle -->
+    <ItemGroup>
+        <Content Include="wwwroot\**" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
+    <Target Name="CopyWwwrootToAppBundle" AfterTargets="Build">
+        <ItemGroup>
+            <WwwrootFiles Include="wwwroot\**\*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(WwwrootFiles)"
+              DestinationFiles="@(WwwrootFiles->'$(OutputPath)$(RuntimeIdentifier)\AppBundle\%(RecursiveDir)%(Filename)%(Extension)')"
+              SkipUnchangedFiles="true" />
+    </Target>
+
 </Project>

--- a/src/NodeGraph.Web/Program.cs
+++ b/src/NodeGraph.Web/Program.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Versioning;
+using Avalonia;
+using Avalonia.Browser;
+using NodeGraph.Web;
+
+[assembly: SupportedOSPlatform("browser")]
+
+internal sealed partial class Program
+{
+    private static async Task Main(string[] args)
+    {
+        await BuildAvaloniaApp()
+            .WithInterFont()
+            .StartBrowserAppAsync("out");
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<WebApp>();
+}

--- a/src/NodeGraph.Web/Properties/launchSettings.json
+++ b/src/NodeGraph.Web/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "NodeGraph.Web": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:5000"
+    }
+  }
+}

--- a/src/NodeGraph.Web/Services/BrowserParameterService.cs
+++ b/src/NodeGraph.Web/Services/BrowserParameterService.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using NodeGraph.Web.Storage;
+
+namespace NodeGraph.Web.Services;
+
+/// <summary>
+/// ブラウザ用のパラメータサービス。localStorageを使用してパラメータを保存。
+/// </summary>
+public class BrowserParameterService
+{
+    private const string StorageKey = "nodegraph:parameters";
+    private const string PresetsPrefix = "nodegraph:preset:";
+    private const string PresetsListKey = "nodegraph:presets";
+    private readonly IStorageProvider _storage;
+    private Dictionary<string, object?> _parameters = [];
+    private List<string> _presetNames = [];
+
+    public BrowserParameterService(IStorageProvider storage)
+    {
+        _storage = storage;
+        _ = LoadAsync();
+        _ = LoadPresetsListAsync();
+    }
+
+    /// <summary>
+    /// パラメータを取得
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> GetParameters()
+    {
+        return _parameters;
+    }
+
+    /// <summary>
+    /// パラメータを設定
+    /// </summary>
+    public async Task SetParameterAsync(string name, object? value)
+    {
+        _parameters[name] = value;
+        await SaveAsync();
+    }
+
+    /// <summary>
+    /// パラメータを削除
+    /// </summary>
+    public async Task RemoveParameterAsync(string name)
+    {
+        _parameters.Remove(name);
+        await SaveAsync();
+    }
+
+    /// <summary>
+    /// 再読み込み
+    /// </summary>
+    public async Task ReloadAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var json = await _storage.ReadTextAsync(StorageKey);
+        if (string.IsNullOrEmpty(json))
+        {
+            _parameters = [];
+            return;
+        }
+
+        try
+        {
+            var data = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(json);
+            _parameters = data ?? [];
+        }
+        catch
+        {
+            _parameters = [];
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        var json = JsonSerializer.Serialize(_parameters);
+        await _storage.WriteTextAsync(StorageKey, json);
+    }
+
+    // ===== プリセット機能 =====
+
+    /// <summary>
+    /// プリセット一覧を取得
+    /// </summary>
+    public IReadOnlyList<string> GetPresetNames() => _presetNames;
+
+    /// <summary>
+    /// 現在のパラメータをプリセットとして保存
+    /// </summary>
+    public async Task SavePresetAsync(string name)
+    {
+        var json = JsonSerializer.Serialize(_parameters);
+        await _storage.WriteTextAsync($"{PresetsPrefix}{name}", json);
+
+        if (!_presetNames.Contains(name))
+        {
+            _presetNames.Add(name);
+            await SavePresetsListAsync();
+        }
+    }
+
+    /// <summary>
+    /// プリセットを読み込んで現在のパラメータに適用
+    /// </summary>
+    public async Task LoadPresetAsync(string name)
+    {
+        var json = await _storage.ReadTextAsync($"{PresetsPrefix}{name}");
+        if (string.IsNullOrEmpty(json))
+            return;
+
+        try
+        {
+            var data = JsonSerializer.Deserialize<Dictionary<string, object?>>(json);
+            if (data != null)
+            {
+                _parameters = data;
+                await SaveAsync();
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    /// <summary>
+    /// プリセットを削除
+    /// </summary>
+    public async Task DeletePresetAsync(string name)
+    {
+        await _storage.DeleteAsync($"{PresetsPrefix}{name}");
+        _presetNames.Remove(name);
+        await SavePresetsListAsync();
+    }
+
+    /// <summary>
+    /// プリセット一覧を再読み込み
+    /// </summary>
+    public async Task ReloadPresetsAsync()
+    {
+        await LoadPresetsListAsync();
+    }
+
+    private async Task LoadPresetsListAsync()
+    {
+        var json = await _storage.ReadTextAsync(PresetsListKey);
+        if (string.IsNullOrEmpty(json))
+        {
+            _presetNames = [];
+            return;
+        }
+
+        try
+        {
+            var data = JsonSerializer.Deserialize<List<string>>(json);
+            _presetNames = data ?? [];
+        }
+        catch
+        {
+            _presetNames = [];
+        }
+    }
+
+    private async Task SavePresetsListAsync()
+    {
+        var json = JsonSerializer.Serialize(_presetNames);
+        await _storage.WriteTextAsync(PresetsListKey, json);
+    }
+}

--- a/src/NodeGraph.Web/Storage/BrowserStorageProvider.cs
+++ b/src/NodeGraph.Web/Storage/BrowserStorageProvider.cs
@@ -1,0 +1,105 @@
+using System.Runtime.InteropServices.JavaScript;
+
+namespace NodeGraph.Web.Storage;
+
+/// <summary>
+/// ブラウザのlocalStorageを使用するストレージプロバイダー
+/// </summary>
+public partial class BrowserStorageProvider : IStorageProvider
+{
+    private const string GraphPrefix = "nodegraph:graph:";
+    private const string LayoutPrefix = "nodegraph:layout:";
+    private const string MetaPrefix = "nodegraph:meta:";
+
+    public Task<string?> ReadTextAsync(string key)
+    {
+        var value = LocalStorageGetItem(key);
+        return Task.FromResult(value);
+    }
+
+    public Task WriteTextAsync(string key, string content)
+    {
+        LocalStorageSetItem(key, content);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ExistsAsync(string key)
+    {
+        var value = LocalStorageGetItem(key);
+        return Task.FromResult(value != null);
+    }
+
+    public Task DeleteAsync(string key)
+    {
+        LocalStorageRemoveItem(key);
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<string>> ListKeysAsync(string prefix = "")
+    {
+        var keys = new List<string>();
+        var length = LocalStorageLength();
+
+        for (var i = 0; i < length; i++)
+        {
+            var key = LocalStorageKey(i);
+            if (key != null && (string.IsNullOrEmpty(prefix) || key.StartsWith(prefix)))
+            {
+                keys.Add(key);
+            }
+        }
+
+        return Task.FromResult<IEnumerable<string>>(keys);
+    }
+
+    public Task DownloadFileAsync(string filename, string content)
+    {
+        DownloadFile(filename, content);
+        return Task.CompletedTask;
+    }
+
+    public async Task<(string filename, string content)?> UploadFileAsync()
+    {
+        var result = await UploadFileFromInput();
+        if (string.IsNullOrEmpty(result))
+        {
+            return null;
+        }
+
+        // Format: "filename\n---CONTENT---\ncontent"
+        var separatorIndex = result.IndexOf("\n---CONTENT---\n", StringComparison.Ordinal);
+        if (separatorIndex < 0)
+        {
+            return null;
+        }
+
+        var filename = result[..separatorIndex];
+        var content = result[(separatorIndex + 15)..];
+        return (filename, content);
+    }
+
+    #region JavaScript Interop
+
+    [JSImport("globalThis.localStorage.getItem")]
+    private static partial string? LocalStorageGetItem(string key);
+
+    [JSImport("globalThis.localStorage.setItem")]
+    private static partial void LocalStorageSetItem(string key, string value);
+
+    [JSImport("globalThis.localStorage.removeItem")]
+    private static partial void LocalStorageRemoveItem(string key);
+
+    [JSImport("globalThis.localStorage.key")]
+    private static partial string? LocalStorageKey(int index);
+
+    [JSImport("globalThis.localStorage.length", "main.js")]
+    private static partial int LocalStorageLength();
+
+    [JSImport("downloadFile", "main.js")]
+    private static partial void DownloadFile(string filename, string content);
+
+    [JSImport("uploadFile", "main.js")]
+    private static partial Task<string> UploadFileFromInput();
+
+    #endregion
+}

--- a/src/NodeGraph.Web/Storage/BrowserStorageProvider.cs
+++ b/src/NodeGraph.Web/Storage/BrowserStorageProvider.cs
@@ -7,10 +7,6 @@ namespace NodeGraph.Web.Storage;
 /// </summary>
 public partial class BrowserStorageProvider : IStorageProvider
 {
-    private const string GraphPrefix = "nodegraph:graph:";
-    private const string LayoutPrefix = "nodegraph:layout:";
-    private const string MetaPrefix = "nodegraph:meta:";
-
     public Task<string?> ReadTextAsync(string key)
     {
         var value = LocalStorageGetItem(key);
@@ -38,7 +34,7 @@ public partial class BrowserStorageProvider : IStorageProvider
     public Task<IEnumerable<string>> ListKeysAsync(string prefix = "")
     {
         var keys = new List<string>();
-        var length = LocalStorageLength();
+        var length = GetLocalStorageLength();
 
         for (var i = 0; i < length; i++)
         {
@@ -92,13 +88,13 @@ public partial class BrowserStorageProvider : IStorageProvider
     [JSImport("globalThis.localStorage.key")]
     private static partial string? LocalStorageKey(int index);
 
-    [JSImport("globalThis.localStorage.length", "main.js")]
-    private static partial int LocalStorageLength();
+    [JSImport("globalThis.getLocalStorageLength")]
+    private static partial int GetLocalStorageLength();
 
-    [JSImport("downloadFile", "main.js")]
+    [JSImport("globalThis.downloadFile")]
     private static partial void DownloadFile(string filename, string content);
 
-    [JSImport("uploadFile", "main.js")]
+    [JSImport("globalThis.uploadFile")]
     private static partial Task<string> UploadFileFromInput();
 
     #endregion

--- a/src/NodeGraph.Web/Storage/IStorageProvider.cs
+++ b/src/NodeGraph.Web/Storage/IStorageProvider.cs
@@ -1,0 +1,43 @@
+namespace NodeGraph.Web.Storage;
+
+/// <summary>
+/// ストレージプロバイダーのインターフェース。
+/// デスクトップではファイルシステム、Webではブラウザストレージを使用。
+/// </summary>
+public interface IStorageProvider
+{
+    /// <summary>
+    /// 指定されたキーのテキストデータを読み込む
+    /// </summary>
+    Task<string?> ReadTextAsync(string key);
+
+    /// <summary>
+    /// 指定されたキーにテキストデータを書き込む
+    /// </summary>
+    Task WriteTextAsync(string key, string content);
+
+    /// <summary>
+    /// 指定されたキーが存在するかどうかを確認する
+    /// </summary>
+    Task<bool> ExistsAsync(string key);
+
+    /// <summary>
+    /// 指定されたキーを削除する
+    /// </summary>
+    Task DeleteAsync(string key);
+
+    /// <summary>
+    /// 指定されたプレフィックスで始まるキーの一覧を取得する
+    /// </summary>
+    Task<IEnumerable<string>> ListKeysAsync(string prefix = "");
+
+    /// <summary>
+    /// ファイルをダウンロードする（Web用）
+    /// </summary>
+    Task DownloadFileAsync(string filename, string content);
+
+    /// <summary>
+    /// ファイルをアップロードする（Web用）
+    /// </summary>
+    Task<(string filename, string content)?> UploadFileAsync();
+}

--- a/src/NodeGraph.Web/ViewModels/DashboardViewModel.cs
+++ b/src/NodeGraph.Web/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,177 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NodeGraph.Web.Storage;
+
+namespace NodeGraph.Web.ViewModels;
+
+/// <summary>
+/// ダッシュボードのViewModel。グラフ一覧の管理を行う。
+/// </summary>
+public partial class DashboardViewModel : ViewModelBase
+{
+    private readonly IStorageProvider _storage;
+    private const string GraphPrefix = "nodegraph:graph:";
+    private const string MetaPrefix = "nodegraph:meta:";
+
+    public ObservableCollection<GraphItemViewModel> Graphs { get; } = new();
+
+    [ObservableProperty]
+    private GraphItemViewModel? _selectedGraph;
+
+    [ObservableProperty]
+    private bool _isLoading;
+
+    public event EventHandler<EditGraphEventArgs>? EditGraphRequested;
+
+    public DashboardViewModel(IStorageProvider storage)
+    {
+        _storage = storage;
+        _ = LoadGraphsAsync();
+    }
+
+    [RelayCommand]
+    private async Task LoadGraphsAsync()
+    {
+        IsLoading = true;
+        try
+        {
+            Graphs.Clear();
+
+            var keys = await _storage.ListKeysAsync(GraphPrefix);
+            foreach (var key in keys)
+            {
+                var graphName = key[GraphPrefix.Length..];
+                var meta = await LoadMetaAsync(graphName);
+
+                Graphs.Add(new GraphItemViewModel
+                {
+                    Name = graphName,
+                    LastModified = meta?.LastModified ?? DateTime.Now,
+                    NodeCount = meta?.NodeCount ?? 0,
+                    ConnectionCount = meta?.ConnectionCount ?? 0
+                });
+            }
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private void NewGraph()
+    {
+        var graphName = $"Graph_{DateTime.Now:yyyyMMdd_HHmmss}";
+        EditGraphRequested?.Invoke(this, new EditGraphEventArgs(graphName, isNew: true));
+    }
+
+    [RelayCommand]
+    private async Task UploadGraphAsync()
+    {
+        var result = await _storage.UploadFileAsync();
+        if (result == null) return;
+
+        var (filename, content) = result.Value;
+
+        // ファイル名からグラフ名を生成
+        var graphName = Path.GetFileNameWithoutExtension(filename);
+        if (graphName.EndsWith(".graph"))
+        {
+            graphName = graphName[..^6]; // ".graph" を除去
+        }
+
+        // 保存
+        await _storage.WriteTextAsync($"{GraphPrefix}{graphName}", content);
+
+        // メタデータを更新
+        await SaveMetaAsync(graphName, new GraphMeta
+        {
+            LastModified = DateTime.Now,
+            NodeCount = 0,
+            ConnectionCount = 0
+        });
+
+        // 一覧を更新
+        await LoadGraphsAsync();
+    }
+
+    [RelayCommand]
+    private void EditGraph(GraphItemViewModel? item)
+    {
+        if (item == null) return;
+        EditGraphRequested?.Invoke(this, new EditGraphEventArgs(item.Name, isNew: false));
+    }
+
+    [RelayCommand]
+    private async Task DownloadGraphAsync(GraphItemViewModel? item)
+    {
+        if (item == null) return;
+
+        var content = await _storage.ReadTextAsync($"{GraphPrefix}{item.Name}");
+        if (content == null) return;
+
+        await _storage.DownloadFileAsync($"{item.Name}.graph.yml", content);
+    }
+
+    [RelayCommand]
+    private async Task DeleteGraphAsync(GraphItemViewModel? item)
+    {
+        if (item == null) return;
+
+        await _storage.DeleteAsync($"{GraphPrefix}{item.Name}");
+        await _storage.DeleteAsync($"{MetaPrefix}{item.Name}");
+        await _storage.DeleteAsync($"nodegraph:layout:{item.Name}");
+
+        Graphs.Remove(item);
+    }
+
+    private async Task<GraphMeta?> LoadMetaAsync(string graphName)
+    {
+        var json = await _storage.ReadTextAsync($"{MetaPrefix}{graphName}");
+        if (string.IsNullOrEmpty(json)) return null;
+
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<GraphMeta>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task SaveMetaAsync(string graphName, GraphMeta meta)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(meta);
+        await _storage.WriteTextAsync($"{MetaPrefix}{graphName}", json);
+    }
+}
+
+/// <summary>
+/// グラフアイテムのViewModel
+/// </summary>
+public partial class GraphItemViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    [ObservableProperty]
+    private DateTime _lastModified;
+
+    [ObservableProperty]
+    private int _nodeCount;
+
+    [ObservableProperty]
+    private int _connectionCount;
+}
+
+/// <summary>
+/// グラフのメタデータ
+/// </summary>
+public class GraphMeta
+{
+    public DateTime LastModified { get; set; }
+    public int NodeCount { get; set; }
+    public int ConnectionCount { get; set; }
+}

--- a/src/NodeGraph.Web/ViewModels/GraphEditorViewModel.cs
+++ b/src/NodeGraph.Web/ViewModels/GraphEditorViewModel.cs
@@ -1,0 +1,186 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NodeGraph.Editor.Models;
+using NodeGraph.Editor.Selection;
+using NodeGraph.Editor.Serialization;
+using NodeGraph.Editor.Services;
+using NodeGraph.Model;
+using NodeGraph.Model.Serialization;
+using NodeGraph.Web.Storage;
+
+namespace NodeGraph.Web.ViewModels;
+
+/// <summary>
+/// グラフエディタのViewModel
+/// </summary>
+public partial class GraphEditorViewModel : ViewModelBase
+{
+    private readonly IStorageProvider _storage;
+    private readonly NodeTypeService _nodeTypeService;
+    private readonly SelectionManager _selectionManager;
+
+    private const string GraphPrefix = "nodegraph:graph:";
+    private const string LayoutPrefix = "nodegraph:layout:";
+    private const string MetaPrefix = "nodegraph:meta:";
+
+    [ObservableProperty]
+    private EditorGraph? _graph;
+
+    [ObservableProperty]
+    private string _graphName = string.Empty;
+
+    [ObservableProperty]
+    private bool _isExecuting;
+
+    [ObservableProperty]
+    private string _executionStatus = "Ready";
+
+    [ObservableProperty]
+    private bool _hasChanges;
+
+    public ObservableCollection<string> ExecutionLogs { get; } = new();
+
+    public event EventHandler? BackToDashboardRequested;
+
+    public GraphEditorViewModel(
+        IStorageProvider storage,
+        NodeTypeService nodeTypeService,
+        SelectionManager selectionManager)
+    {
+        _storage = storage;
+        _nodeTypeService = nodeTypeService;
+        _selectionManager = selectionManager;
+    }
+
+    /// <summary>
+    /// 新規グラフを作成
+    /// </summary>
+    public void CreateNewGraph(string name)
+    {
+        GraphName = name;
+        var graph = new Graph();
+        Graph = new EditorGraph(graph, _selectionManager);
+        HasChanges = true;
+    }
+
+    /// <summary>
+    /// グラフを読み込む
+    /// </summary>
+    public async Task LoadGraphAsync(string name)
+    {
+        GraphName = name;
+
+        var yaml = await _storage.ReadTextAsync($"{GraphPrefix}{name}");
+        if (string.IsNullOrEmpty(yaml))
+        {
+            CreateNewGraph(name);
+            return;
+        }
+
+        try
+        {
+            var graph = GraphSerializer.Deserialize(yaml);
+            Graph = new EditorGraph(graph, _selectionManager);
+
+            // レイアウトを読み込む
+            var layoutYaml = await _storage.ReadTextAsync($"{LayoutPrefix}{name}");
+            if (!string.IsNullOrEmpty(layoutYaml))
+            {
+                EditorLayoutSerializer.LoadLayout(layoutYaml, Graph);
+            }
+
+            HasChanges = false;
+        }
+        catch (Exception ex)
+        {
+            ExecutionLogs.Add($"Error loading graph: {ex.Message}");
+            CreateNewGraph(name);
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        if (Graph == null) return;
+
+        try
+        {
+            // グラフを保存
+            var yaml = GraphSerializer.Serialize(Graph.Graph);
+            await _storage.WriteTextAsync($"{GraphPrefix}{GraphName}", yaml);
+
+            // レイアウトを保存
+            var layoutYaml = EditorLayoutSerializer.SaveLayout(Graph);
+            await _storage.WriteTextAsync($"{LayoutPrefix}{GraphName}", layoutYaml);
+
+            // メタデータを保存
+            var meta = new GraphMeta
+            {
+                LastModified = DateTime.Now,
+                NodeCount = Graph.Nodes.Count,
+                ConnectionCount = Graph.Connections.Count
+            };
+            var metaJson = System.Text.Json.JsonSerializer.Serialize(meta);
+            await _storage.WriteTextAsync($"{MetaPrefix}{GraphName}", metaJson);
+
+            HasChanges = false;
+            ExecutionLogs.Add($"Saved: {GraphName}");
+        }
+        catch (Exception ex)
+        {
+            ExecutionLogs.Add($"Error saving: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private async Task DownloadAsync()
+    {
+        if (Graph == null) return;
+
+        var yaml = GraphSerializer.Serialize(Graph.Graph);
+        await _storage.DownloadFileAsync($"{GraphName}.graph.yml", yaml);
+    }
+
+    [RelayCommand]
+    private async Task ExecuteAsync()
+    {
+        if (Graph == null) return;
+
+        IsExecuting = true;
+        ExecutionStatus = "Executing...";
+        ExecutionLogs.Clear();
+
+        var startTime = DateTime.Now;
+
+        try
+        {
+            await Graph.ExecuteAsync(null, null, CancellationToken.None);
+
+            var elapsed = DateTime.Now - startTime;
+            ExecutionStatus = $"Completed ({elapsed.TotalMilliseconds:F0}ms)";
+            ExecutionLogs.Add($"Execution completed successfully in {elapsed.TotalMilliseconds:F0}ms");
+        }
+        catch (Exception ex)
+        {
+            ExecutionStatus = "Error";
+            ExecutionLogs.Add($"Error: {ex.Message}");
+        }
+        finally
+        {
+            IsExecuting = false;
+        }
+    }
+
+    [RelayCommand]
+    private void BackToDashboard()
+    {
+        BackToDashboardRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void ClearLogs()
+    {
+        ExecutionLogs.Clear();
+    }
+}

--- a/src/NodeGraph.Web/ViewModels/GraphEditorViewModel.cs
+++ b/src/NodeGraph.Web/ViewModels/GraphEditorViewModel.cs
@@ -24,6 +24,11 @@ public partial class GraphEditorViewModel : ViewModelBase
     private const string LayoutPrefix = "nodegraph:layout:";
     private const string MetaPrefix = "nodegraph:meta:";
 
+    /// <summary>
+    /// パラメータパネルのViewModel
+    /// </summary>
+    public ParametersPanelViewModel ParametersPanel { get; }
+
     [ObservableProperty]
     private EditorGraph? _graph;
 
@@ -46,11 +51,13 @@ public partial class GraphEditorViewModel : ViewModelBase
     public GraphEditorViewModel(
         IStorageProvider storage,
         NodeTypeService nodeTypeService,
-        SelectionManager selectionManager)
+        SelectionManager selectionManager,
+        ParametersPanelViewModel parametersPanel)
     {
         _storage = storage;
         _nodeTypeService = nodeTypeService;
         _selectionManager = selectionManager;
+        ParametersPanel = parametersPanel;
     }
 
     /// <summary>

--- a/src/NodeGraph.Web/ViewModels/MainShellViewModel.cs
+++ b/src/NodeGraph.Web/ViewModels/MainShellViewModel.cs
@@ -1,0 +1,87 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NodeGraph.Web.ViewModels;
+
+/// <summary>
+/// メインシェルのViewModel。ナビゲーションを管理する。
+/// </summary>
+public partial class MainShellViewModel : ViewModelBase
+{
+    private readonly IServiceProvider _services;
+
+    [ObservableProperty]
+    private ViewModelBase? _currentView;
+
+    [ObservableProperty]
+    private string _currentViewName = "Dashboard";
+
+    [ObservableProperty]
+    private bool _isDashboardView = true;
+
+    public MainShellViewModel(IServiceProvider services)
+    {
+        _services = services;
+        NavigateToDashboard();
+    }
+
+    [RelayCommand]
+    private void NavigateToDashboard()
+    {
+        var dashboard = _services.GetRequiredService<DashboardViewModel>();
+        dashboard.EditGraphRequested += OnEditGraphRequested;
+        CurrentView = dashboard;
+        CurrentViewName = "Dashboard";
+        IsDashboardView = true;
+    }
+
+    [RelayCommand]
+    private void NavigateToEditor()
+    {
+        var editor = _services.GetRequiredService<GraphEditorViewModel>();
+        editor.BackToDashboardRequested += OnBackToDashboardRequested;
+        CurrentView = editor;
+        CurrentViewName = "Editor";
+        IsDashboardView = false;
+    }
+
+    private void OnEditGraphRequested(object? sender, EditGraphEventArgs e)
+    {
+        var editor = _services.GetRequiredService<GraphEditorViewModel>();
+        editor.BackToDashboardRequested += OnBackToDashboardRequested;
+
+        if (e.IsNew)
+        {
+            editor.CreateNewGraph(e.GraphName);
+        }
+        else
+        {
+            _ = editor.LoadGraphAsync(e.GraphName);
+        }
+
+        CurrentView = editor;
+        CurrentViewName = "Editor";
+        IsDashboardView = false;
+    }
+
+    private void OnBackToDashboardRequested(object? sender, EventArgs e)
+    {
+        NavigateToDashboard();
+    }
+}
+
+/// <summary>
+/// グラフ編集リクエストのイベント引数
+/// </summary>
+public class EditGraphEventArgs : EventArgs
+{
+    public string GraphName { get; }
+    public bool IsNew { get; }
+
+    public EditGraphEventArgs(string graphName, bool isNew)
+    {
+        GraphName = graphName;
+        IsNew = isNew;
+    }
+}

--- a/src/NodeGraph.Web/ViewModels/ParametersPanelViewModel.cs
+++ b/src/NodeGraph.Web/ViewModels/ParametersPanelViewModel.cs
@@ -1,0 +1,190 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NodeGraph.Web.Services;
+
+namespace NodeGraph.Web.ViewModels;
+
+/// <summary>
+/// パラメータパネルのViewModel
+/// </summary>
+public partial class ParametersPanelViewModel : ViewModelBase
+{
+    private readonly BrowserParameterService _parameterService;
+
+    public ObservableCollection<ParameterItemViewModel> Parameters { get; } = [];
+    public ObservableCollection<string> Presets { get; } = [];
+
+    [ObservableProperty]
+    private ParameterItemViewModel? _selectedParameter;
+
+    [ObservableProperty]
+    private string? _selectedPreset;
+
+    [ObservableProperty]
+    private string _newParameterName = string.Empty;
+
+    [ObservableProperty]
+    private string _newParameterValue = string.Empty;
+
+    [ObservableProperty]
+    private string _newPresetName = string.Empty;
+
+    public ParametersPanelViewModel(BrowserParameterService parameterService)
+    {
+        _parameterService = parameterService;
+        LoadParameters();
+        LoadPresets();
+    }
+
+    /// <summary>
+    /// パラメータを読み込む
+    /// </summary>
+    private void LoadParameters()
+    {
+        foreach (var param in Parameters)
+        {
+            param.ValueChanged -= OnParameterValueChanged;
+        }
+
+        Parameters.Clear();
+
+        var allParams = _parameterService.GetParameters();
+        foreach (var kvp in allParams)
+        {
+            var item = new ParameterItemViewModel
+            {
+                Name = kvp.Key,
+                Value = kvp.Value?.ToString() ?? string.Empty
+            };
+            item.ValueChanged += OnParameterValueChanged;
+            Parameters.Add(item);
+        }
+    }
+
+    private async void OnParameterValueChanged(ParameterItemViewModel item)
+    {
+        await _parameterService.SetParameterAsync(item.Name, item.Value);
+    }
+
+    [RelayCommand]
+    private async Task AddParameterAsync()
+    {
+        if (string.IsNullOrWhiteSpace(NewParameterName))
+            return;
+
+        var name = NewParameterName.Trim();
+        await _parameterService.SetParameterAsync(name, NewParameterValue);
+
+        var existing = Parameters.FirstOrDefault(p => p.Name == name);
+        if (existing != null)
+        {
+            existing.Value = NewParameterValue;
+        }
+        else
+        {
+            var item = new ParameterItemViewModel
+            {
+                Name = name,
+                Value = NewParameterValue
+            };
+            item.ValueChanged += OnParameterValueChanged;
+            Parameters.Add(item);
+        }
+
+        NewParameterName = string.Empty;
+        NewParameterValue = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task DeleteParameterAsync()
+    {
+        if (SelectedParameter == null)
+            return;
+
+        SelectedParameter.ValueChanged -= OnParameterValueChanged;
+        await _parameterService.RemoveParameterAsync(SelectedParameter.Name);
+        Parameters.Remove(SelectedParameter);
+        SelectedParameter = null;
+    }
+
+    [RelayCommand]
+    private async Task ReloadAsync()
+    {
+        await _parameterService.ReloadAsync();
+        LoadParameters();
+        await _parameterService.ReloadPresetsAsync();
+        LoadPresets();
+    }
+
+    // ===== プリセット機能 =====
+
+    /// <summary>
+    /// プリセット一覧を読み込む
+    /// </summary>
+    private void LoadPresets()
+    {
+        Presets.Clear();
+        foreach (var name in _parameterService.GetPresetNames())
+        {
+            Presets.Add(name);
+        }
+    }
+
+    [RelayCommand]
+    private async Task SavePresetAsync()
+    {
+        if (string.IsNullOrWhiteSpace(NewPresetName))
+            return;
+
+        var name = NewPresetName.Trim();
+        await _parameterService.SavePresetAsync(name);
+
+        if (!Presets.Contains(name))
+        {
+            Presets.Add(name);
+        }
+
+        NewPresetName = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task LoadPresetAsync()
+    {
+        if (string.IsNullOrEmpty(SelectedPreset))
+            return;
+
+        await _parameterService.LoadPresetAsync(SelectedPreset);
+        LoadParameters();
+    }
+
+    [RelayCommand]
+    private async Task DeletePresetAsync()
+    {
+        if (string.IsNullOrEmpty(SelectedPreset))
+            return;
+
+        await _parameterService.DeletePresetAsync(SelectedPreset);
+        Presets.Remove(SelectedPreset);
+        SelectedPreset = null;
+    }
+}
+
+/// <summary>
+/// パラメータ項目のViewModel
+/// </summary>
+public partial class ParameterItemViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    [ObservableProperty]
+    private string _value = string.Empty;
+
+    public event Action<ParameterItemViewModel>? ValueChanged;
+
+    partial void OnValueChanged(string value)
+    {
+        ValueChanged?.Invoke(this);
+    }
+}

--- a/src/NodeGraph.Web/ViewModels/ViewModelBase.cs
+++ b/src/NodeGraph.Web/ViewModels/ViewModelBase.cs
@@ -1,0 +1,10 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace NodeGraph.Web.ViewModels;
+
+/// <summary>
+/// ViewModelの基底クラス
+/// </summary>
+public abstract class ViewModelBase : ObservableObject
+{
+}

--- a/src/NodeGraph.Web/Views/DashboardView.axaml
+++ b/src/NodeGraph.Web/Views/DashboardView.axaml
@@ -1,0 +1,150 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:NodeGraph.Web.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
+             x:Class="NodeGraph.Web.Views.DashboardView"
+             x:DataType="vm:DashboardViewModel">
+
+    <Grid ColumnDefinitions="300,*" Margin="16">
+        <!-- Left Panel: Graph List -->
+        <Border Grid.Column="0"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                CornerRadius="8"
+                Padding="16"
+                Margin="0,0,8,0">
+            <Grid RowDefinitions="Auto,Auto,*">
+                <TextBlock Grid.Row="0"
+                           Text="Graphs"
+                           FontSize="18"
+                           FontWeight="SemiBold"
+                           Margin="0,0,0,16" />
+
+                <StackPanel Grid.Row="1" Spacing="8" Margin="0,0,0,16">
+                    <Button Content="+ New Graph"
+                            Command="{Binding NewGraphCommand}"
+                            HorizontalAlignment="Stretch"
+                            Classes="accent" />
+                    <Button Content="Upload Graph"
+                            Command="{Binding UploadGraphCommand}"
+                            HorizontalAlignment="Stretch" />
+                    <Button Content="Refresh"
+                            Command="{Binding LoadGraphsCommand}"
+                            HorizontalAlignment="Stretch" />
+                </StackPanel>
+
+                <ListBox Grid.Row="2"
+                         ItemsSource="{Binding Graphs}"
+                         SelectedItem="{Binding SelectedGraph}"
+                         Background="Transparent">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="vm:GraphItemViewModel">
+                            <Border Padding="8"
+                                    Margin="0,4"
+                                    Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                                    CornerRadius="4">
+                                <Grid RowDefinitions="Auto,Auto">
+                                    <TextBlock Grid.Row="0"
+                                               Text="{Binding Name}"
+                                               FontWeight="SemiBold" />
+                                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Opacity="0.7">
+                                        <TextBlock Text="{Binding NodeCount, StringFormat='{}{0} nodes'}" FontSize="11" />
+                                        <TextBlock Text="|" FontSize="11" />
+                                        <TextBlock Text="{Binding LastModified, StringFormat='{}{0:yyyy/MM/dd HH:mm}'}" FontSize="11" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+        </Border>
+
+        <!-- Right Panel: Details & Actions -->
+        <Border Grid.Column="1"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                CornerRadius="8"
+                Padding="24"
+                Margin="8,0,0,0">
+            <Grid RowDefinitions="Auto,*,Auto">
+                <TextBlock Grid.Row="0"
+                           Text="Graph Details"
+                           FontSize="18"
+                           FontWeight="SemiBold"
+                           Margin="0,0,0,24" />
+
+                <!-- No Selection -->
+                <StackPanel Grid.Row="1"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center"
+                            IsVisible="{Binding SelectedGraph, Converter={x:Static ObjectConverters.IsNull}}">
+                    <TextBlock Text="Select a graph from the list"
+                               FontSize="16"
+                               Opacity="0.5"
+                               HorizontalAlignment="Center" />
+                    <TextBlock Text="or create a new one"
+                               FontSize="14"
+                               Opacity="0.4"
+                               HorizontalAlignment="Center"
+                               Margin="0,8,0,0" />
+                </StackPanel>
+
+                <!-- Graph Details -->
+                <StackPanel Grid.Row="1"
+                            IsVisible="{Binding SelectedGraph, Converter={x:Static ObjectConverters.IsNotNull}}"
+                            Spacing="16">
+                    <StackPanel>
+                        <TextBlock Text="Name" FontWeight="SemiBold" Opacity="0.7" />
+                        <TextBlock Text="{Binding SelectedGraph.Name}" FontSize="24" />
+                    </StackPanel>
+
+                    <StackPanel>
+                        <TextBlock Text="Statistics" FontWeight="SemiBold" Opacity="0.7" />
+                        <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" Margin="0,8,0,0">
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Nodes:" Margin="0,0,16,4" />
+                            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedGraph.NodeCount}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connections:" Margin="0,0,16,4" />
+                            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedGraph.ConnectionCount}" />
+                        </Grid>
+                    </StackPanel>
+
+                    <StackPanel>
+                        <TextBlock Text="Last Modified" FontWeight="SemiBold" Opacity="0.7" />
+                        <TextBlock Text="{Binding SelectedGraph.LastModified, StringFormat='{}{0:yyyy/MM/dd HH:mm:ss}'}"
+                                   FontSize="14"
+                                   Margin="0,4,0,0" />
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- Actions -->
+                <StackPanel Grid.Row="2"
+                            Orientation="Horizontal"
+                            Spacing="8"
+                            HorizontalAlignment="Right"
+                            IsVisible="{Binding SelectedGraph, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <Button Content="Edit"
+                            Command="{Binding EditGraphCommand}"
+                            CommandParameter="{Binding SelectedGraph}"
+                            Classes="accent" />
+                    <Button Content="Download"
+                            Command="{Binding DownloadGraphCommand}"
+                            CommandParameter="{Binding SelectedGraph}" />
+                    <Button Content="Delete"
+                            Command="{Binding DeleteGraphCommand}"
+                            CommandParameter="{Binding SelectedGraph}" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Loading Overlay -->
+        <Border Grid.ColumnSpan="2"
+                Background="#80000000"
+                IsVisible="{Binding IsLoading}">
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <ProgressBar IsIndeterminate="True" Width="200" />
+                <TextBlock Text="Loading..." HorizontalAlignment="Center" Margin="0,8,0,0" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/NodeGraph.Web/Views/DashboardView.axaml.cs
+++ b/src/NodeGraph.Web/Views/DashboardView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace NodeGraph.Web.Views;
+
+public partial class DashboardView : UserControl
+{
+    public DashboardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NodeGraph.Web/Views/GraphEditorView.axaml
+++ b/src/NodeGraph.Web/Views/GraphEditorView.axaml
@@ -1,0 +1,125 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:NodeGraph.Web.ViewModels"
+             xmlns:controls="using:NodeGraph.Editor.Controls"
+             mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
+             x:Class="NodeGraph.Web.Views.GraphEditorView"
+             x:DataType="vm:GraphEditorViewModel">
+
+    <Grid RowDefinitions="Auto,*,Auto">
+        <!-- Toolbar -->
+        <Border Grid.Row="0"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                Padding="16,8">
+            <Grid ColumnDefinitions="Auto,*,Auto">
+                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                    <Button Content="Back"
+                            Command="{Binding BackToDashboardCommand}" />
+                    <TextBlock Text="|" VerticalAlignment="Center" Opacity="0.3" />
+                    <TextBlock Text="{Binding GraphName}"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center" />
+                    <TextBlock Text="*"
+                               IsVisible="{Binding HasChanges}"
+                               FontSize="16"
+                               VerticalAlignment="Center"
+                               Foreground="Orange" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
+                    <Button Content="Save"
+                            Command="{Binding SaveCommand}"
+                            Classes="accent" />
+                    <Button Content="Download"
+                            Command="{Binding DownloadCommand}" />
+                    <Button Content="Execute"
+                            Command="{Binding ExecuteCommand}"
+                            IsEnabled="{Binding !IsExecuting}"
+                            Background="Green"
+                            Foreground="White" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Main Content -->
+        <Grid Grid.Row="1" ColumnDefinitions="*,300">
+            <!-- Graph Canvas -->
+            <Border Grid.Column="0"
+                    Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                    Margin="0,0,4,0">
+                <controls:GraphControl Graph="{Binding Graph}" />
+            </Border>
+
+            <!-- Right Panel: Execution & Logs -->
+            <Border Grid.Column="1"
+                    Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                    Padding="16"
+                    Margin="4,0,0,0">
+                <Grid RowDefinitions="Auto,Auto,*,Auto">
+                    <TextBlock Grid.Row="0"
+                               Text="Execution"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,16" />
+
+                    <!-- Status -->
+                    <Border Grid.Row="1"
+                            Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                            CornerRadius="4"
+                            Padding="12"
+                            Margin="0,0,0,16">
+                        <StackPanel>
+                            <TextBlock Text="Status" FontWeight="SemiBold" Opacity="0.7" FontSize="12" />
+                            <TextBlock Text="{Binding ExecutionStatus}" FontSize="14" Margin="0,4,0,0" />
+                            <ProgressBar IsIndeterminate="True"
+                                         IsVisible="{Binding IsExecuting}"
+                                         Margin="0,8,0,0" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Logs -->
+                    <Grid Grid.Row="2" RowDefinitions="Auto,*">
+                        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+                            <TextBlock Text="Logs" FontWeight="SemiBold" Opacity="0.7" FontSize="12" />
+                            <Button Grid.Column="1"
+                                    Content="Clear"
+                                    Command="{Binding ClearLogsCommand}"
+                                    Padding="8,2"
+                                    FontSize="11" />
+                        </Grid>
+                        <ListBox Grid.Row="1"
+                                 ItemsSource="{Binding ExecutionLogs}"
+                                 Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                                 CornerRadius="4">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}"
+                                               FontFamily="Consolas, monospace"
+                                               FontSize="11"
+                                               TextWrapping="Wrap" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <!-- Status Bar -->
+        <Border Grid.Row="2"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                Padding="16,4">
+            <StackPanel Orientation="Horizontal" Spacing="16">
+                <TextBlock Text="{Binding Graph.Nodes.Count, StringFormat='Nodes: {0}', FallbackValue='Nodes: 0'}"
+                           FontSize="12"
+                           Opacity="0.7" />
+                <TextBlock Text="{Binding Graph.Connections.Count, StringFormat='Connections: {0}', FallbackValue='Connections: 0'}"
+                           FontSize="12"
+                           Opacity="0.7" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/NodeGraph.Web/Views/GraphEditorView.axaml
+++ b/src/NodeGraph.Web/Views/GraphEditorView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:NodeGraph.Web.ViewModels"
+             xmlns:views="using:NodeGraph.Web.Views"
              xmlns:controls="using:NodeGraph.Editor.Controls"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="NodeGraph.Web.Views.GraphEditorView"
@@ -45,16 +46,24 @@
         </Border>
 
         <!-- Main Content -->
-        <Grid Grid.Row="1" ColumnDefinitions="*,300">
-            <!-- Graph Canvas -->
+        <Grid Grid.Row="1" ColumnDefinitions="250,*,300">
+            <!-- Left Panel: Parameters -->
             <Border Grid.Column="0"
-                    Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                    Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                    Padding="16"
                     Margin="0,0,4,0">
+                <views:ParametersPanel DataContext="{Binding ParametersPanel}" />
+            </Border>
+
+            <!-- Graph Canvas -->
+            <Border Grid.Column="1"
+                    Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                    Margin="4,0,4,0">
                 <controls:GraphControl Graph="{Binding Graph}" />
             </Border>
 
             <!-- Right Panel: Execution & Logs -->
-            <Border Grid.Column="1"
+            <Border Grid.Column="2"
                     Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
                     Padding="16"
                     Margin="4,0,0,0">

--- a/src/NodeGraph.Web/Views/GraphEditorView.axaml.cs
+++ b/src/NodeGraph.Web/Views/GraphEditorView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace NodeGraph.Web.Views;
+
+public partial class GraphEditorView : UserControl
+{
+    public GraphEditorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NodeGraph.Web/Views/MainShellView.axaml
+++ b/src/NodeGraph.Web/Views/MainShellView.axaml
@@ -1,0 +1,53 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:NodeGraph.Web.ViewModels"
+             xmlns:views="using:NodeGraph.Web.Views"
+             mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
+             x:Class="NodeGraph.Web.Views.MainShellView"
+             x:DataType="vm:MainShellViewModel">
+
+    <UserControl.DataTemplates>
+        <DataTemplate DataType="vm:DashboardViewModel">
+            <views:DashboardView />
+        </DataTemplate>
+        <DataTemplate DataType="vm:GraphEditorViewModel">
+            <views:GraphEditorView />
+        </DataTemplate>
+    </UserControl.DataTemplates>
+
+    <Grid RowDefinitions="Auto,*">
+        <!-- Header -->
+        <Border Grid.Row="0"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                Padding="16,8">
+            <Grid ColumnDefinitions="Auto,*,Auto">
+                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="16">
+                    <TextBlock Text="NodeGraph Web"
+                               FontSize="20"
+                               FontWeight="Bold"
+                               VerticalAlignment="Center" />
+                    <TextBlock Text="|"
+                               FontSize="20"
+                               Opacity="0.5"
+                               VerticalAlignment="Center" />
+                    <TextBlock Text="{Binding CurrentViewName}"
+                               FontSize="16"
+                               VerticalAlignment="Center"
+                               Opacity="0.8" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
+                    <Button Content="Dashboard"
+                            Command="{Binding NavigateToDashboardCommand}"
+                            IsVisible="{Binding !IsDashboardView}"
+                            Classes="accent" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Content -->
+        <ContentControl Grid.Row="1" Content="{Binding CurrentView}" />
+    </Grid>
+</UserControl>

--- a/src/NodeGraph.Web/Views/MainShellView.axaml.cs
+++ b/src/NodeGraph.Web/Views/MainShellView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace NodeGraph.Web.Views;
+
+public partial class MainShellView : UserControl
+{
+    public MainShellView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NodeGraph.Web/Views/ParametersPanel.axaml
+++ b/src/NodeGraph.Web/Views/ParametersPanel.axaml
@@ -1,0 +1,145 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:NodeGraph.Web.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="400"
+             x:Class="NodeGraph.Web.Views.ParametersPanel"
+             x:DataType="vm:ParametersPanelViewModel">
+
+    <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto">
+        <!-- Header -->
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+            <TextBlock Text="Parameters"
+                       FontSize="16"
+                       FontWeight="SemiBold" />
+            <Button Grid.Column="1"
+                    Content="Reload"
+                    Command="{Binding ReloadCommand}"
+                    Padding="8,2"
+                    FontSize="11" />
+        </Grid>
+
+        <!-- Parameter List -->
+        <Border Grid.Row="1"
+                Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                CornerRadius="4"
+                Margin="0,0,0,8">
+            <ListBox ItemsSource="{Binding Parameters}"
+                     SelectedItem="{Binding SelectedParameter}"
+                     Background="Transparent">
+                <ListBox.ItemTemplate>
+                    <DataTemplate DataType="vm:ParameterItemViewModel">
+                        <Grid ColumnDefinitions="*,*" Margin="4,2">
+                            <TextBlock Grid.Column="0"
+                                       Text="{Binding Name}"
+                                       VerticalAlignment="Center"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,8,0" />
+                            <TextBox Grid.Column="1"
+                                     Text="{Binding Value}"
+                                     FontSize="12" />
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Border>
+
+        <!-- Add New Parameter -->
+        <Border Grid.Row="2"
+                Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                CornerRadius="4"
+                Padding="8"
+                Margin="0,0,0,8">
+            <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Row="0" Grid.Column="0"
+                           Text="Name:"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,4" />
+                <TextBox Grid.Row="0" Grid.Column="1"
+                         Text="{Binding NewParameterName}"
+                         Margin="0,0,0,4" />
+
+                <TextBlock Grid.Row="1" Grid.Column="0"
+                           Text="Value:"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,4" />
+                <TextBox Grid.Row="1" Grid.Column="1"
+                         Text="{Binding NewParameterValue}"
+                         Margin="0,0,0,4" />
+
+                <Button Grid.Row="2" Grid.ColumnSpan="2"
+                        Content="Add Parameter"
+                        Command="{Binding AddParameterCommand}"
+                        HorizontalAlignment="Stretch"
+                        Margin="0,4,0,0" />
+            </Grid>
+        </Border>
+
+        <!-- Delete Button -->
+        <Button Grid.Row="3"
+                Content="Delete Selected"
+                Command="{Binding DeleteParameterCommand}"
+                IsEnabled="{Binding SelectedParameter, Converter={x:Static ObjectConverters.IsNotNull}}"
+                HorizontalAlignment="Stretch" />
+
+        <!-- Presets Section Separator -->
+        <Border Grid.Row="4"
+                Height="1"
+                Background="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                Margin="0,12,0,8"
+                Opacity="0.3" />
+
+        <!-- Presets Header -->
+        <TextBlock Grid.Row="5"
+                   Text="Presets"
+                   FontSize="14"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,8" />
+
+        <!-- Presets Panel -->
+        <Border Grid.Row="6"
+                Background="{DynamicResource SystemControlBackgroundChromeLowBrush}"
+                CornerRadius="4"
+                Padding="8">
+            <Grid RowDefinitions="Auto,Auto,Auto">
+                <!-- Preset List -->
+                <ListBox Grid.Row="0"
+                         ItemsSource="{Binding Presets}"
+                         SelectedItem="{Binding SelectedPreset}"
+                         Background="Transparent"
+                         MinHeight="60"
+                         MaxHeight="100"
+                         Margin="0,0,0,8" />
+
+                <!-- Save New Preset -->
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+                    <TextBox Grid.Column="0"
+                             Text="{Binding NewPresetName}"
+                             Watermark="Preset name..."
+                             Margin="0,0,4,0" />
+                    <Button Grid.Column="1"
+                            Content="Save"
+                            Command="{Binding SavePresetCommand}"
+                            Padding="8,4" />
+                </Grid>
+
+                <!-- Preset Actions -->
+                <Grid Grid.Row="2" ColumnDefinitions="*,*">
+                    <Button Grid.Column="0"
+                            Content="Load"
+                            Command="{Binding LoadPresetCommand}"
+                            IsEnabled="{Binding SelectedPreset, Converter={x:Static ObjectConverters.IsNotNull}}"
+                            HorizontalAlignment="Stretch"
+                            Margin="0,0,4,0" />
+                    <Button Grid.Column="1"
+                            Content="Delete"
+                            Command="{Binding DeletePresetCommand}"
+                            IsEnabled="{Binding SelectedPreset, Converter={x:Static ObjectConverters.IsNotNull}}"
+                            HorizontalAlignment="Stretch"
+                            Margin="4,0,0,0" />
+                </Grid>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/NodeGraph.Web/Views/ParametersPanel.axaml.cs
+++ b/src/NodeGraph.Web/Views/ParametersPanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace NodeGraph.Web.Views;
+
+public partial class ParametersPanel : UserControl
+{
+    public ParametersPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NodeGraph.Web/WebApp.axaml
+++ b/src/NodeGraph.Web/WebApp.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="NodeGraph.Web.WebApp"
+             RequestedThemeVariant="Default">
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/src/NodeGraph.Web/WebApp.axaml
+++ b/src/NodeGraph.Web/WebApp.axaml
@@ -1,8 +1,18 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="using:NodeGraph.Editor.Converters"
              x:Class="NodeGraph.Web.WebApp"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Dark">
+
+    <Application.Resources>
+        <converters:TypeToColorConverter x:Key="TypeToColorConverter" />
+    </Application.Resources>
+
     <Application.Styles>
         <FluentTheme />
+
+        <!-- NodeGraph Editor themes -->
+        <StyleInclude Source="avares://NodeGraph.Editor/Themes/NodeGraphEditorTheme.axaml" />
+        <StyleInclude Source="avares://NodeGraph.Editor/Themes/SvgPath.axaml" />
     </Application.Styles>
 </Application>

--- a/src/NodeGraph.Web/WebApp.axaml.cs
+++ b/src/NodeGraph.Web/WebApp.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using NodeGraph.Editor.Selection;
 using NodeGraph.Editor.Services;
+using NodeGraph.Web.Services;
 using NodeGraph.Web.Storage;
 using NodeGraph.Web.ViewModels;
 using NodeGraph.Web.Views;
@@ -43,11 +44,13 @@ public class WebApp : Application
         // Register shared services
         services.AddSingleton<NodeTypeService>();
         services.AddSingleton<SelectionManager>();
+        services.AddSingleton<BrowserParameterService>();
 
         // Register ViewModels
         services.AddTransient<MainShellViewModel>();
         services.AddTransient<DashboardViewModel>();
         services.AddTransient<GraphEditorViewModel>();
+        services.AddTransient<ParametersPanelViewModel>();
 
         return services.BuildServiceProvider();
     }

--- a/src/NodeGraph.Web/WebApp.axaml.cs
+++ b/src/NodeGraph.Web/WebApp.axaml.cs
@@ -1,0 +1,54 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using Microsoft.Extensions.DependencyInjection;
+using NodeGraph.Editor.Selection;
+using NodeGraph.Editor.Services;
+using NodeGraph.Web.Storage;
+using NodeGraph.Web.ViewModels;
+using NodeGraph.Web.Views;
+
+namespace NodeGraph.Web;
+
+public class WebApp : Application
+{
+    private ServiceProvider? _services;
+
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
+        {
+            _services = ConfigureServices();
+            singleView.MainView = new MainShellView
+            {
+                DataContext = _services.GetRequiredService<MainShellViewModel>()
+            };
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+
+    private static ServiceProvider ConfigureServices()
+    {
+        var services = new ServiceCollection();
+
+        // Register browser-specific storage
+        services.AddSingleton<IStorageProvider, BrowserStorageProvider>();
+
+        // Register shared services
+        services.AddSingleton<NodeTypeService>();
+        services.AddSingleton<SelectionManager>();
+
+        // Register ViewModels
+        services.AddTransient<MainShellViewModel>();
+        services.AddTransient<DashboardViewModel>();
+        services.AddTransient<GraphEditorViewModel>();
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/NodeGraph.Web/serve.ps1
+++ b/src/NodeGraph.Web/serve.ps1
@@ -12,6 +12,10 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
+# wwwroot をコピー
+Write-Host "Copying wwwroot files..." -ForegroundColor Cyan
+Copy-Item -Path ".\wwwroot\*" -Destination $AppBundlePath -Force -Recurse
+
 # AppBundle が存在するか確認
 if (-not (Test-Path $AppBundlePath)) {
     Write-Host "AppBundle not found at $AppBundlePath" -ForegroundColor Red

--- a/src/NodeGraph.Web/serve.ps1
+++ b/src/NodeGraph.Web/serve.ps1
@@ -1,0 +1,25 @@
+# NodeGraph.Web 起動スクリプト
+# 使用方法: .\serve.ps1
+
+$AppBundlePath = ".\bin\Debug\net9.0-browser\browser-wasm\AppBundle"
+
+# ビルド
+Write-Host "Building NodeGraph.Web..." -ForegroundColor Cyan
+dotnet build
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Build failed!" -ForegroundColor Red
+    exit 1
+}
+
+# AppBundle が存在するか確認
+if (-not (Test-Path $AppBundlePath)) {
+    Write-Host "AppBundle not found at $AppBundlePath" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Starting server at http://localhost:5000" -ForegroundColor Green
+Write-Host "Press Ctrl+C to stop" -ForegroundColor Yellow
+
+# dotnet-serve を使用
+dotnet serve -d $AppBundlePath -p 5000 -o

--- a/src/NodeGraph.Web/wwwroot/index.html
+++ b/src/NodeGraph.Web/wwwroot/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NodeGraph Web</title>
+    <style>
+        html, body, #out {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+
+        #out {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: #1e1e1e;
+        }
+
+        .loading {
+            color: #ffffff;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 16px;
+        }
+
+        .loading::after {
+            content: '';
+            animation: dots 1.5s steps(4, end) infinite;
+        }
+
+        @keyframes dots {
+            0%, 20% { content: ''; }
+            40% { content: '.'; }
+            60% { content: '..'; }
+            80%, 100% { content: '...'; }
+        }
+    </style>
+</head>
+<body>
+    <div id="out">
+        <div class="loading">Loading NodeGraph</div>
+    </div>
+    <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/src/NodeGraph.Web/wwwroot/index.html
+++ b/src/NodeGraph.Web/wwwroot/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NodeGraph Web</title>
     <style>
-        html, body, #out {
+        html, body {
             margin: 0;
             padding: 0;
             width: 100%;
@@ -14,35 +14,60 @@
         }
 
         #out {
+            width: 100%;
+            height: 100%;
+        }
+
+        #loading {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
             display: flex;
+            flex-direction: column;
             align-items: center;
             justify-content: center;
             background-color: #1e1e1e;
-        }
-
-        .loading {
             color: #ffffff;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            font-size: 16px;
+            z-index: 9999;
+            transition: opacity 0.3s ease-out;
         }
 
-        .loading::after {
-            content: '';
-            animation: dots 1.5s steps(4, end) infinite;
+        #loading.hidden {
+            opacity: 0;
+            pointer-events: none;
         }
 
-        @keyframes dots {
-            0%, 20% { content: ''; }
-            40% { content: '.'; }
-            60% { content: '..'; }
-            80%, 100% { content: '...'; }
+        .loading-text {
+            font-size: 18px;
+            margin-bottom: 16px;
+        }
+
+        .loading-spinner {
+            width: 40px;
+            height: 40px;
+            border: 4px solid #333;
+            border-top: 4px solid #0078d4;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
         }
     </style>
 </head>
 <body>
-    <div id="out">
-        <div class="loading">Loading NodeGraph</div>
+    <!-- Loading overlay (separate from Avalonia container) -->
+    <div id="loading">
+        <div class="loading-spinner"></div>
+        <div class="loading-text">Loading NodeGraph...</div>
     </div>
+    <!-- Avalonia container -->
+    <div id="out"></div>
     <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/src/NodeGraph.Web/wwwroot/main.js
+++ b/src/NodeGraph.Web/wwwroot/main.js
@@ -1,0 +1,59 @@
+import { dotnet } from './_framework/dotnet.js';
+
+// .NET WebAssemblyランタイムを初期化
+const { setModuleImports, getAssemblyExports, getConfig } = await dotnet
+    .withDiagnosticTracing(false)
+    .create();
+
+// JavaScript関数をエクスポート
+setModuleImports('main.js', {
+    // ファイルダウンロード
+    downloadFile: (filename, content) => {
+        const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    },
+
+    // ファイルアップロード
+    uploadFile: () => {
+        return new Promise((resolve) => {
+            const input = document.createElement('input');
+            input.type = 'file';
+            input.accept = '.graph.yml,.yml,.yaml';
+
+            input.onchange = async (e) => {
+                const file = e.target.files?.[0];
+                if (!file) {
+                    resolve('');
+                    return;
+                }
+
+                const content = await file.text();
+                // Format: "filename\n---CONTENT---\ncontent"
+                resolve(`${file.name}\n---CONTENT---\n${content}`);
+            };
+
+            input.oncancel = () => {
+                resolve('');
+            };
+
+            input.click();
+        });
+    },
+
+    // localStorage.length を取得するラッパー
+    'globalThis.localStorage.length': () => {
+        return localStorage.length;
+    }
+});
+
+const config = getConfig();
+const exports = await getAssemblyExports(config.mainAssemblyName);
+
+await dotnet.run();

--- a/src/NodeGraph.Web/wwwroot/main.js
+++ b/src/NodeGraph.Web/wwwroot/main.js
@@ -1,59 +1,90 @@
 import { dotnet } from './_framework/dotnet.js';
 
-// .NET WebAssemblyランタイムを初期化
-const { setModuleImports, getAssemblyExports, getConfig } = await dotnet
-    .withDiagnosticTracing(false)
-    .create();
-
-// JavaScript関数をエクスポート
-setModuleImports('main.js', {
-    // ファイルダウンロード
-    downloadFile: (filename, content) => {
-        const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
-    },
-
-    // ファイルアップロード
-    uploadFile: () => {
-        return new Promise((resolve) => {
-            const input = document.createElement('input');
-            input.type = 'file';
-            input.accept = '.graph.yml,.yml,.yaml';
-
-            input.onchange = async (e) => {
-                const file = e.target.files?.[0];
-                if (!file) {
-                    resolve('');
-                    return;
-                }
-
-                const content = await file.text();
-                // Format: "filename\n---CONTENT---\ncontent"
-                resolve(`${file.name}\n---CONTENT---\n${content}`);
-            };
-
-            input.oncancel = () => {
-                resolve('');
-            };
-
-            input.click();
-        });
-    },
-
-    // localStorage.length を取得するラッパー
-    'globalThis.localStorage.length': () => {
-        return localStorage.length;
+// ブラウザのデフォルトコンテキストメニューを抑制（Avaloniaアプリ用）
+document.addEventListener('contextmenu', (e) => {
+    // #out内（Avaloniaコンテナ）での右クリックのみ抑制
+    const out = document.getElementById('out');
+    if (out && out.contains(e.target)) {
+        e.preventDefault();
     }
 });
 
-const config = getConfig();
-const exports = await getAssemblyExports(config.mainAssemblyName);
+// localStorage の長さを取得
+globalThis.getLocalStorageLength = () => {
+    return localStorage.length;
+};
 
-await dotnet.run();
+// ファイルダウンロード機能
+globalThis.downloadFile = (filename, content) => {
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+};
+
+// ファイルアップロード機能
+globalThis.uploadFile = () => {
+    return new Promise((resolve) => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = '.graph.yml,.yml,.yaml';
+
+        input.onchange = async (e) => {
+            const file = e.target.files?.[0];
+            if (!file) {
+                resolve('');
+                return;
+            }
+
+            const content = await file.text();
+            resolve(`${file.name}\n---CONTENT---\n${content}`);
+        };
+
+        input.oncancel = () => {
+            resolve('');
+        };
+
+        input.click();
+    });
+};
+
+// .NET ランタイムを起動 (.NET 9 WASM)
+const runtime = await dotnet
+    .withDiagnosticTracing(false)
+    .withApplicationArgumentsFromQuery()
+    .create();
+
+// ローディング画面を非表示にする
+const hideLoading = () => {
+    const loading = document.getElementById('loading');
+    if (loading) {
+        loading.classList.add('hidden');
+        // フェードアウト後に完全に削除
+        setTimeout(() => loading.remove(), 300);
+    }
+};
+
+// Avaloniaが最初のフレームをレンダリングした後にローディングを非表示
+// MutationObserverで#out内にコンテンツが追加されたことを検知
+const observer = new MutationObserver((mutations, obs) => {
+    const out = document.getElementById('out');
+    if (out && out.children.length > 0) {
+        hideLoading();
+        obs.disconnect();
+    }
+});
+
+observer.observe(document.getElementById('out'), {
+    childList: true,
+    subtree: true
+});
+
+// フォールバック: 5秒後に強制的に非表示
+setTimeout(hideLoading, 5000);
+
+await runtime.runMain();


### PR DESCRIPTION
## Summary
- Avalonia WebAssembly (WASM) 対応によりブラウザからNodeGraphエディタを利用可能に
- ダッシュボードUIでグラフの一覧表示・作成・編集・削除・ダウンロード機能を実装
- パラメータパネルとプリセット管理機能を追加

## 実装内容

### Phase 1-3: プロジェクト基盤
- `NodeGraph.Web` プロジェクト新規作成 (`net9.0-browser`, `browser-wasm`)
- `IStorageProvider` インターフェースと `BrowserStorageProvider` (localStorage使用)
- `MainShellView` によるナビゲーション管理

### Phase 4: ダッシュボード
- グラフ一覧表示・プレビュー
- 新規グラフ作成・編集・削除
- グラフのダウンロード機能

### Phase 5: グラフエディタ
- 既存の `GraphControl` を再利用
- 自動保存 (localStorage)
- 実行ステータスとログ表示

### Phase 6: パラメータ設定
- `ParametersPanel` UserControl
- パラメータの追加・編集・削除
- プリセット管理（保存・読み込み・削除）

### Phase 7: 実行機能
- Execute ボタンによるグラフ実行
- ProgressBar による実行中表示
- 実行ログとステータス表示

## Test plan
- [ ] `dotnet build src/NodeGraph.Web/NodeGraph.Web.csproj` でビルド成功
- [ ] `dotnet serve --port 5500` でブラウザからアクセス可能
- [ ] ダッシュボードでグラフの作成・編集・削除ができる
- [ ] グラフエディタでノードの追加・接続ができる
- [ ] パラメータの追加・編集・プリセット保存/読み込みができる
- [ ] グラフの実行とログ表示ができる

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)