### PR TITLE
feat: Add plugin loading system for dynamic node discovery

### DIFF
--- a/NodeGraph.slnx
+++ b/NodeGraph.slnx
@@ -8,5 +8,6 @@
     </Folder>
     <Folder Name="/test/">
         <Project Path="test\NodeGraph.UnitTest\NodeGraph.UnitTest.csproj" Type="C#" />
+        <Project Path="test\NodeGraph.SamplePlugin\NodeGraph.SamplePlugin.csproj" Type="C#" />
     </Folder>
 </Solution>

--- a/src/NodeGraph.Editor/Services/PluginAssemblyLoadContext.cs
+++ b/src/NodeGraph.Editor/Services/PluginAssemblyLoadContext.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace NodeGraph.Editor.Services;
+
+/// <summary>
+/// プラグインアセンブリをロードするためのカスタムAssemblyLoadContext
+/// プラグインの分離と依存関係の解決を行う
+/// </summary>
+public class PluginAssemblyLoadContext : AssemblyLoadContext
+{
+    private readonly string _pluginsDirectory;
+    private readonly AssemblyDependencyResolver _resolver;
+
+    /// <summary>
+    /// 新しいPluginAssemblyLoadContextを作成する
+    /// </summary>
+    /// <param name="mainPluginPath">メインプラグインDLLのパス（依存解決の基点）</param>
+    /// <param name="pluginsDirectory">プラグインディレクトリのパス</param>
+    public PluginAssemblyLoadContext(string mainPluginPath, string pluginsDirectory)
+        : base(isCollectible: false) // アンロード不要のためfalse
+    {
+        _pluginsDirectory = pluginsDirectory;
+        _resolver = new AssemblyDependencyResolver(mainPluginPath);
+    }
+
+    /// <summary>
+    /// アセンブリをロードする
+    /// </summary>
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // 1. deps.jsonベースの依存解決を試行
+        var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (assemblyPath != null)
+            return LoadFromAssemblyPath(assemblyPath);
+
+        // 2. Pluginsディレクトリ内を再帰的に検索
+        var dllName = assemblyName.Name + ".dll";
+        try
+        {
+            var matchingFiles = Directory.GetFiles(_pluginsDirectory, dllName, SearchOption.AllDirectories);
+            if (matchingFiles.Length > 0)
+                return LoadFromAssemblyPath(matchingFiles[0]);
+        }
+        catch
+        {
+            // ディレクトリアクセスエラーは無視
+        }
+
+        // 3. デフォルトコンテキストにフォールバック（共有フレームワークアセンブリ用）
+        return null;
+    }
+
+    /// <summary>
+    /// アンマネージDLLをロードする
+    /// </summary>
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        var libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        return libraryPath != null ? LoadUnmanagedDllFromPath(libraryPath) : IntPtr.Zero;
+    }
+}

--- a/src/NodeGraph.Editor/Services/PluginLoadResult.cs
+++ b/src/NodeGraph.Editor/Services/PluginLoadResult.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace NodeGraph.Editor.Services;
+
+/// <summary>
+/// プラグインロード操作の結果を表すクラス
+/// </summary>
+public class PluginLoadResult
+{
+    /// <summary>
+    /// ロードを試みたDLLのパス
+    /// </summary>
+    public required string DllPath { get; init; }
+
+    /// <summary>
+    /// ロードが成功したかどうか
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// エラーメッセージ（失敗時のみ設定）
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// 発見されたノードタイプのリスト
+    /// </summary>
+    public IReadOnlyList<Type> DiscoveredNodeTypes { get; init; } = [];
+}

--- a/src/NodeGraph.Editor/Services/PluginScanner.cs
+++ b/src/NodeGraph.Editor/Services/PluginScanner.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace NodeGraph.Editor.Services;
+
+/// <summary>
+/// DLLをスキャンして[Node]属性を持つ型が含まれているかを検査するクラス
+/// ランタイムにロードせずにメタデータのみを読み取る
+/// </summary>
+public class PluginScanner
+{
+    private const string NodeAttributeFullName = "NodeGraph.Model.NodeAttribute";
+
+    /// <summary>
+    /// DLLに[Node]属性を持つ型が含まれているかを検査する
+    /// </summary>
+    /// <param name="dllPath">検査するDLLのパス</param>
+    /// <returns>[Node]属性を持つ型が存在する場合はtrue</returns>
+    public bool ContainsNodeTypes(string dllPath)
+    {
+        try
+        {
+            using var fs = new FileStream(dllPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var peReader = new PEReader(fs);
+
+            if (!peReader.HasMetadata)
+                return false;
+
+            var metadataReader = peReader.GetMetadataReader();
+
+            // 全てのカスタム属性をスキャン
+            foreach (var attrHandle in metadataReader.CustomAttributes)
+            {
+                var attr = metadataReader.GetCustomAttribute(attrHandle);
+                if (IsNodeAttribute(metadataReader, attr))
+                    return true;
+            }
+
+            return false;
+        }
+        catch
+        {
+            // ファイルアクセスエラー、無効なPE形式などはfalseを返す
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 指定されたカスタム属性がNodeAttributeかどうかを判定する
+    /// </summary>
+    private static bool IsNodeAttribute(MetadataReader reader, CustomAttribute attr)
+    {
+        try
+        {
+            // コンストラクタ参照から型を取得
+            if (attr.Constructor.Kind == HandleKind.MemberReference)
+            {
+                var memberRef = reader.GetMemberReference((MemberReferenceHandle)attr.Constructor);
+                if (memberRef.Parent.Kind == HandleKind.TypeReference)
+                {
+                    var typeRef = reader.GetTypeReference((TypeReferenceHandle)memberRef.Parent);
+                    var fullName = GetFullTypeName(reader, typeRef);
+                    return fullName == NodeAttributeFullName;
+                }
+            }
+            else if (attr.Constructor.Kind == HandleKind.MethodDefinition)
+            {
+                var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)attr.Constructor);
+                var typeDef = reader.GetTypeDefinition(methodDef.GetDeclaringType());
+                var fullName = GetFullTypeName(reader, typeDef);
+                return fullName == NodeAttributeFullName;
+            }
+        }
+        catch
+        {
+            // メタデータ読み取りエラーは無視
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// TypeReferenceからフルネームを取得
+    /// </summary>
+    private static string GetFullTypeName(MetadataReader reader, TypeReference typeRef)
+    {
+        var typeName = reader.GetString(typeRef.Name);
+        var typeNamespace = reader.GetString(typeRef.Namespace);
+        return string.IsNullOrEmpty(typeNamespace) ? typeName : $"{typeNamespace}.{typeName}";
+    }
+
+    /// <summary>
+    /// TypeDefinitionからフルネームを取得
+    /// </summary>
+    private static string GetFullTypeName(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var typeName = reader.GetString(typeDef.Name);
+        var typeNamespace = reader.GetString(typeDef.Namespace);
+        return string.IsNullOrEmpty(typeNamespace) ? typeName : $"{typeNamespace}.{typeName}";
+    }
+
+    /// <summary>
+    /// 指定されたディレクトリ内のすべてのDLLファイルを列挙する
+    /// </summary>
+    /// <param name="pluginsDirectory">プラグインディレクトリのパス</param>
+    /// <returns>DLLファイルのパスの列挙</returns>
+    public IEnumerable<string> EnumerateDlls(string pluginsDirectory)
+    {
+        if (!Directory.Exists(pluginsDirectory))
+            yield break;
+
+        foreach (var dll in Directory.EnumerateFiles(pluginsDirectory, "*.dll", SearchOption.AllDirectories))
+            yield return dll;
+    }
+}

--- a/src/NodeGraph.Editor/Services/PluginService.cs
+++ b/src/NodeGraph.Editor/Services/PluginService.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using NodeGraph.Model;
+
+namespace NodeGraph.Editor.Services;
+
+/// <summary>
+/// プラグインの発見、ロード、登録を統括するサービス
+/// </summary>
+public class PluginService
+{
+    private readonly List<PluginLoadResult> _loadResults = [];
+    private readonly List<Type> _pluginNodeTypes = [];
+    private readonly HashSet<string> _loadedAssemblyNames = [];
+
+    /// <summary>
+    /// プラグインロード結果のリスト
+    /// </summary>
+    public IReadOnlyList<PluginLoadResult> LoadResults => _loadResults;
+
+    /// <summary>
+    /// 発見されたプラグインノードタイプのリスト
+    /// </summary>
+    public IReadOnlyList<Type> PluginNodeTypes => _pluginNodeTypes;
+
+    /// <summary>
+    /// 指定されたディレクトリからプラグインをロードする
+    /// </summary>
+    /// <param name="pluginsDirectory">プラグインディレクトリのパス</param>
+    public void LoadPlugins(string pluginsDirectory)
+    {
+        _loadResults.Clear();
+        _pluginNodeTypes.Clear();
+
+        var scanner = new PluginScanner();
+
+        // 既にロード済みのアセンブリ名を収集（重複チェック用）
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (!asm.IsDynamic)
+                _loadedAssemblyNames.Add(asm.GetName().Name ?? string.Empty);
+        }
+
+        // プラグインディレクトリ内のすべてのDLLをスキャン
+        foreach (var dllPath in scanner.EnumerateDlls(pluginsDirectory))
+        {
+            var result = TryLoadPlugin(dllPath, pluginsDirectory, scanner);
+            _loadResults.Add(result);
+
+            if (result.Success)
+            {
+                Debug.WriteLine($"[PluginService] Loaded plugin: {dllPath} ({result.DiscoveredNodeTypes.Count} nodes)");
+            }
+            else
+            {
+                Debug.WriteLine($"[PluginService] Skipped: {dllPath} - {result.ErrorMessage}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 単一のDLLをプラグインとしてロードを試みる
+    /// </summary>
+    private PluginLoadResult TryLoadPlugin(string dllPath, string pluginsDirectory, PluginScanner scanner)
+    {
+        try
+        {
+            // Step 1: メタデータ検査（ロードせずに[Node]属性をチェック）
+            if (!scanner.ContainsNodeTypes(dllPath))
+            {
+                return new PluginLoadResult
+                {
+                    DllPath = dllPath,
+                    Success = false,
+                    ErrorMessage = "No [Node] types found"
+                };
+            }
+
+            // Step 2: 重複チェック
+            var assemblyName = AssemblyName.GetAssemblyName(dllPath);
+            if (_loadedAssemblyNames.Contains(assemblyName.Name ?? string.Empty))
+            {
+                return new PluginLoadResult
+                {
+                    DllPath = dllPath,
+                    Success = false,
+                    ErrorMessage = $"Assembly '{assemblyName.Name}' is already loaded"
+                };
+            }
+
+            // Step 3: カスタムコンテキストでアセンブリをロード
+            var loadContext = new PluginAssemblyLoadContext(dllPath, pluginsDirectory);
+            var assembly = loadContext.LoadFromAssemblyPath(dllPath);
+
+            _loadedAssemblyNames.Add(assemblyName.Name ?? string.Empty);
+
+            // Step 4: ノードタイプを発見
+            var nodeTypes = DiscoverNodeTypes(assembly);
+            _pluginNodeTypes.AddRange(nodeTypes);
+
+            return new PluginLoadResult
+            {
+                DllPath = dllPath,
+                Success = true,
+                DiscoveredNodeTypes = nodeTypes
+            };
+        }
+        catch (Exception ex)
+        {
+            return new PluginLoadResult
+            {
+                DllPath = dllPath,
+                Success = false,
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
+    /// <summary>
+    /// アセンブリからNodeを継承する非抽象クラスを発見する
+    /// </summary>
+    private static List<Type> DiscoverNodeTypes(Assembly assembly)
+    {
+        var nodeBaseType = typeof(Node);
+        var result = new List<Type>();
+
+        try
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                if (!type.IsAbstract && type.IsClass && nodeBaseType.IsAssignableFrom(type))
+                    result.Add(type);
+            }
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            // 一部の型のみロードできた場合は、ロードできた型のみ処理
+            foreach (var type in ex.Types)
+            {
+                if (type != null && !type.IsAbstract && type.IsClass && nodeBaseType.IsAssignableFrom(type))
+                    result.Add(type);
+            }
+        }
+
+        return result;
+    }
+}

--- a/test/NodeGraph.SamplePlugin/NodeGraph.SamplePlugin.csproj
+++ b/test/NodeGraph.SamplePlugin/NodeGraph.SamplePlugin.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\NodeGraph.Generator\NodeGraph.Generator.csproj">
+            <OutputItemType>Analyzer</OutputItemType>
+            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\..\src\NodeGraph.Model\NodeGraph.Model.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/test/NodeGraph.SamplePlugin/SampleDoubleNode.cs
+++ b/test/NodeGraph.SamplePlugin/SampleDoubleNode.cs
@@ -1,0 +1,22 @@
+using NodeGraph.Model;
+
+namespace NodeGraph.SamplePlugin;
+
+/// <summary>
+/// サンプルプラグインノード: 入力値を2倍にする
+/// </summary>
+[Node("Double", "Sample Plugin")]
+public partial class SampleDoubleNode : Node
+{
+    [Input]
+    private float _input;
+
+    [Output]
+    private float _output;
+
+    protected override Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        _output = _input * 2;
+        return context.ExecuteOutAsync(0);
+    }
+}

--- a/test/NodeGraph.SamplePlugin/SampleReverseStringNode.cs
+++ b/test/NodeGraph.SamplePlugin/SampleReverseStringNode.cs
@@ -1,0 +1,24 @@
+using NodeGraph.Model;
+
+namespace NodeGraph.SamplePlugin;
+
+/// <summary>
+/// サンプルプラグインノード: 文字列を逆順にする
+/// </summary>
+[Node("Reverse String", "Sample Plugin")]
+public partial class SampleReverseStringNode : Node
+{
+    [Input]
+    private string _input = string.Empty;
+
+    [Output]
+    private string _output = string.Empty;
+
+    protected override Task ExecuteCoreAsync(NodeExecutionContext context)
+    {
+        var chars = _input.ToCharArray();
+        Array.Reverse(chars);
+        _output = new string(chars);
+        return context.ExecuteOutAsync(0);
+    }
+}

--- a/test/NodeGraph.UnitTest/NodeGraph.UnitTest.csproj
+++ b/test/NodeGraph.UnitTest/NodeGraph.UnitTest.csproj
@@ -33,6 +33,24 @@
 
         <ProjectReference Include="..\..\src\NodeGraph.Model\NodeGraph.Model.csproj"/>
         <ProjectReference Include="..\..\src\NodeGraph.Editor\NodeGraph.Editor.csproj"/>
+
+        <!-- SamplePluginはビルドするが参照しない（プラグインとしてロードするため） -->
+        <ProjectReference Include="..\NodeGraph.SamplePlugin\NodeGraph.SamplePlugin.csproj">
+            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+            <Private>false</Private>
+        </ProjectReference>
     </ItemGroup>
+
+    <!-- ビルド後にSamplePluginをPluginsフォルダにコピー -->
+    <Target Name="CopySamplePluginToPlugins" AfterTargets="Build">
+        <PropertyGroup>
+            <SamplePluginOutputDir>$(MSBuildThisFileDirectory)..\NodeGraph.SamplePlugin\bin\$(Configuration)\net9.0\</SamplePluginOutputDir>
+            <PluginsDir>$(OutputPath)Plugins\</PluginsDir>
+        </PropertyGroup>
+        <MakeDir Directories="$(PluginsDir)" />
+        <Copy SourceFiles="$(SamplePluginOutputDir)NodeGraph.SamplePlugin.dll"
+              DestinationFolder="$(PluginsDir)"
+              SkipUnchangedFiles="true" />
+    </Target>
 
 </Project>

--- a/test/NodeGraph.UnitTest/Plugin/PluginIntegrationTest.cs
+++ b/test/NodeGraph.UnitTest/Plugin/PluginIntegrationTest.cs
@@ -1,0 +1,191 @@
+using NodeGraph.Editor.Services;
+using NodeGraph.Model;
+using Xunit;
+
+namespace NodeGraph.UnitTest.Plugin;
+
+/// <summary>
+/// プラグインテスト用のフィクスチャ
+/// テスト間でPluginServiceを共有し、プラグインを一度だけロードする
+/// </summary>
+public class PluginTestFixture : IDisposable
+{
+    public PluginService PluginService { get; }
+    public string PluginsDirectory { get; }
+
+    public PluginTestFixture()
+    {
+        PluginsDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Plugins");
+        PluginService = new PluginService();
+        PluginService.LoadPlugins(PluginsDirectory);
+    }
+
+    public void Dispose()
+    {
+        // クリーンアップは不要（AssemblyLoadContextはアンロード不可）
+    }
+}
+
+/// <summary>
+/// プラグインテストのコレクション定義
+/// このコレクションに属するテストは順次実行される
+/// </summary>
+[CollectionDefinition("PluginTests")]
+public class PluginTestCollection : ICollectionFixture<PluginTestFixture>
+{
+}
+
+/// <summary>
+/// プラグインローディングの統合テスト
+/// SamplePluginを実際にロードして、ノードが正しく発見・登録されることを確認
+/// </summary>
+[Collection("PluginTests")]
+public class PluginIntegrationTest
+{
+    private readonly PluginTestFixture _fixture;
+
+    public PluginIntegrationTest(PluginTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void LoadPlugins_WithSamplePlugin_DiscoversTwoNodes()
+    {
+        // Assert
+        var successResults = _fixture.PluginService.LoadResults.Where(r => r.Success).ToList();
+        Assert.Single(successResults); // SamplePlugin.dllが1つロードされる
+
+        // 2つのノード（SampleDoubleNode, SampleReverseStringNode）が発見される
+        Assert.Equal(2, _fixture.PluginService.PluginNodeTypes.Count);
+    }
+
+    [Fact]
+    public void LoadPlugins_WithSamplePlugin_DiscoversSampleDoubleNode()
+    {
+        // Assert
+        var doubleNodeType = _fixture.PluginService.PluginNodeTypes
+            .FirstOrDefault(t => t.Name == "SampleDoubleNode");
+        Assert.NotNull(doubleNodeType);
+        Assert.True(typeof(Node).IsAssignableFrom(doubleNodeType));
+    }
+
+    [Fact]
+    public void LoadPlugins_WithSamplePlugin_DiscoversSampleReverseStringNode()
+    {
+        // Assert
+        var reverseNodeType = _fixture.PluginService.PluginNodeTypes
+            .FirstOrDefault(t => t.Name == "SampleReverseStringNode");
+        Assert.NotNull(reverseNodeType);
+        Assert.True(typeof(Node).IsAssignableFrom(reverseNodeType));
+    }
+
+    [Fact]
+    public void PluginNode_CanBeInstantiated()
+    {
+        // Act & Assert
+        foreach (var nodeType in _fixture.PluginService.PluginNodeTypes)
+        {
+            var instance = Activator.CreateInstance(nodeType);
+            Assert.NotNull(instance);
+            Assert.IsAssignableFrom<Node>(instance);
+        }
+    }
+
+    [Fact]
+    public void PluginNode_HasCorrectDisplayNameAndDirectory()
+    {
+        // Act
+        var doubleNodeType = _fixture.PluginService.PluginNodeTypes
+            .First(t => t.Name == "SampleDoubleNode");
+        var node = (Node)Activator.CreateInstance(doubleNodeType)!;
+
+        // Assert
+        Assert.Equal("Double", node.GetDisplayName());
+        Assert.Equal("Sample Plugin", node.GetDirectory());
+    }
+
+    [Fact]
+    public void PluginNode_HasCorrectPorts()
+    {
+        // Act
+        var doubleNodeType = _fixture.PluginService.PluginNodeTypes
+            .First(t => t.Name == "SampleDoubleNode");
+        var node = (Node)Activator.CreateInstance(doubleNodeType)!;
+
+        // Assert - 入力ポートと出力ポートが正しく生成されている
+        Assert.Single(node.InputPorts);
+        Assert.Single(node.OutputPorts);
+        Assert.Single(node.ExecInPorts);
+        Assert.Single(node.ExecOutPorts);
+    }
+
+    [Fact]
+    public void NodeTypeService_RegistersPluginTypes()
+    {
+        // Arrange
+        var nodeTypeService = new NodeTypeService();
+
+        // Act
+        nodeTypeService.RegisterPluginTypes(_fixture.PluginService.PluginNodeTypes);
+
+        // Assert
+        var doubleNode = nodeTypeService.NodeTypes
+            .FirstOrDefault(n => n.DisplayName == "Double" && n.Directory == "Sample Plugin");
+        var reverseNode = nodeTypeService.NodeTypes
+            .FirstOrDefault(n => n.DisplayName == "Reverse String" && n.Directory == "Sample Plugin");
+
+        Assert.NotNull(doubleNode);
+        Assert.NotNull(reverseNode);
+    }
+
+    [Fact]
+    public void NodeTypeService_Search_FindsPluginNodes()
+    {
+        // Arrange
+        var nodeTypeService = new NodeTypeService();
+        nodeTypeService.RegisterPluginTypes(_fixture.PluginService.PluginNodeTypes);
+
+        // Act
+        var searchResults = nodeTypeService.Search("Sample Plugin").ToList();
+
+        // Assert
+        Assert.Equal(2, searchResults.Count);
+    }
+
+    [Fact]
+    public void PluginNode_CanConnectToBuiltInNodes()
+    {
+        // Arrange
+        var doubleNodeType = _fixture.PluginService.PluginNodeTypes
+            .First(t => t.Name == "SampleDoubleNode");
+        var pluginNode = (Node)Activator.CreateInstance(doubleNodeType)!;
+
+        var graph = new Graph();
+        var constantNode = graph.CreateNode<FloatConstantNode>();
+        var resultNode = graph.CreateNode<FloatResultNode>();
+
+        // Act - プラグインノードのポートと組み込みノードのポートを接続
+        var connected1 = constantNode.OutputPorts[0].Connect(pluginNode.InputPorts[0]);
+        var connected2 = pluginNode.OutputPorts[0].Connect(resultNode.InputPorts[0]);
+
+        // Assert
+        Assert.True(connected1);
+        Assert.True(connected2);
+        Assert.Single(constantNode.OutputPorts[0].ConnectedPorts);
+        Assert.Single(pluginNode.OutputPorts[0].ConnectedPorts);
+    }
+
+    [Fact]
+    public void LoadPlugins_ReturnsCorrectLoadResult()
+    {
+        // Assert
+        var samplePluginResult = _fixture.PluginService.LoadResults
+            .FirstOrDefault(r => r.DllPath.EndsWith("NodeGraph.SamplePlugin.dll"));
+
+        Assert.NotNull(samplePluginResult);
+        Assert.True(samplePluginResult.Success);
+        Assert.Null(samplePluginResult.ErrorMessage);
+        Assert.Equal(2, samplePluginResult.DiscoveredNodeTypes.Count);
+    }
+}

--- a/test/NodeGraph.UnitTest/Plugin/PluginScannerTest.cs
+++ b/test/NodeGraph.UnitTest/Plugin/PluginScannerTest.cs
@@ -1,0 +1,117 @@
+using NodeGraph.Editor.Services;
+using NodeGraph.Model;
+using Xunit;
+
+namespace NodeGraph.UnitTest.Plugin;
+
+public class PluginScannerTest
+{
+    [Fact]
+    public void ContainsNodeTypes_WithValidPluginDll_ReturnsTrue()
+    {
+        // Arrange: NodeGraph.Model.dllにはNode派生型が含まれている
+        var scanner = new PluginScanner();
+        var modelDllPath = typeof(Node).Assembly.Location;
+
+        // Act
+        var result = scanner.ContainsNodeTypes(modelDllPath);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsNodeTypes_WithNonPluginDll_ReturnsFalse()
+    {
+        // Arrange: xunit.core.dllにはNode型は含まれていない
+        var scanner = new PluginScanner();
+        var xunitDllPath = typeof(FactAttribute).Assembly.Location;
+
+        // Act
+        var result = scanner.ContainsNodeTypes(xunitDllPath);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ContainsNodeTypes_WithInvalidPath_ReturnsFalse()
+    {
+        // Arrange
+        var scanner = new PluginScanner();
+
+        // Act
+        var result = scanner.ContainsNodeTypes("nonexistent.dll");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EnumerateDlls_WithNonExistentDirectory_ReturnsEmpty()
+    {
+        // Arrange
+        var scanner = new PluginScanner();
+        var nonExistentDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        // Act
+        var dlls = scanner.EnumerateDlls(nonExistentDir).ToList();
+
+        // Assert
+        Assert.Empty(dlls);
+    }
+
+    [Fact]
+    public void EnumerateDlls_WithValidDirectory_ReturnsDlls()
+    {
+        // Arrange
+        var scanner = new PluginScanner();
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // ダミーDLLファイルを作成
+            File.WriteAllText(Path.Combine(tempDir, "test1.dll"), "dummy");
+            File.WriteAllText(Path.Combine(tempDir, "test2.dll"), "dummy");
+            File.WriteAllText(Path.Combine(tempDir, "test.txt"), "dummy");
+
+            // Act
+            var dlls = scanner.EnumerateDlls(tempDir).ToList();
+
+            // Assert
+            Assert.Equal(2, dlls.Count);
+            Assert.All(dlls, d => Assert.EndsWith(".dll", d));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void EnumerateDlls_WithSubdirectories_ReturnsDllsRecursively()
+    {
+        // Arrange
+        var scanner = new PluginScanner();
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var subDir = Path.Combine(tempDir, "subdir");
+        Directory.CreateDirectory(subDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "root.dll"), "dummy");
+            File.WriteAllText(Path.Combine(subDir, "sub.dll"), "dummy");
+
+            // Act
+            var dlls = scanner.EnumerateDlls(tempDir).ToList();
+
+            // Assert
+            Assert.Equal(2, dlls.Count);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/test/NodeGraph.UnitTest/Plugin/PluginServiceTest.cs
+++ b/test/NodeGraph.UnitTest/Plugin/PluginServiceTest.cs
@@ -1,0 +1,85 @@
+using NodeGraph.Editor.Services;
+using Xunit;
+
+namespace NodeGraph.UnitTest.Plugin;
+
+public class PluginServiceTest
+{
+    [Fact]
+    public void LoadPlugins_WithEmptyDirectory_ReturnsNoResults()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var service = new PluginService();
+
+            // Act
+            service.LoadPlugins(tempDir);
+
+            // Assert
+            Assert.Empty(service.LoadResults);
+            Assert.Empty(service.PluginNodeTypes);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadPlugins_WithNonExistentDirectory_ReturnsNoResults()
+    {
+        // Arrange
+        var nonExistentDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var service = new PluginService();
+
+        // Act
+        service.LoadPlugins(nonExistentDir);
+
+        // Assert
+        Assert.Empty(service.LoadResults);
+        Assert.Empty(service.PluginNodeTypes);
+    }
+
+    [Fact]
+    public void LoadPlugins_WithInvalidDll_ReturnsFailureResult()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // 無効なDLLファイルを作成
+            File.WriteAllText(Path.Combine(tempDir, "invalid.dll"), "not a dll");
+
+            var service = new PluginService();
+
+            // Act
+            service.LoadPlugins(tempDir);
+
+            // Assert
+            Assert.Single(service.LoadResults);
+            Assert.False(service.LoadResults[0].Success);
+            Assert.Empty(service.PluginNodeTypes);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadResults_InitialState_IsEmpty()
+    {
+        // Arrange & Act
+        var service = new PluginService();
+
+        // Assert
+        Assert.Empty(service.LoadResults);
+        Assert.Empty(service.PluginNodeTypes);
+    }
+}


### PR DESCRIPTION
## Summary
- 起動時に`Plugins`フォルダをスキャンし、外部DLLからカスタムノードを自動ロードする機能を実装
- `PEReader`を使用してDLLをメモリにロードせずに`[Node]`属性の存在を検査
- カスタム`AssemblyLoadContext`でプラグインを分離し、依存関係を解決

## Changes
- **PluginScanner**: DLLのメタデータを検査して`[Node]`属性を持つ型を検出
- **PluginAssemblyLoadContext**: プラグイン分離と依存解決のためのカスタムロードコンテキスト
- **PluginService**: プラグインの発見、ロード、登録を統括
- **PluginLoadResult**: ロード操作の結果を表すデータクラス
- **NodeTypeService**: `RegisterPluginTypes`メソッドを追加
- **App.axaml.cs**: 起動時にプラグインをロード

## Test plan
- [x] ビルドが成功すること
- [x] 全テスト（259件）がパスすること
- [x] `{実行ディレクトリ}/Plugins`フォルダにDLLを配置して、Add Nodeウィンドウにノードが表示されることを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)